### PR TITLE
core: reduce allocs in hot method: priceHeap.Less()

### DIFF
--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -368,7 +368,7 @@ func (l *txList) Flatten() types.Transactions {
 type priceHeap []*types.Transaction
 
 func (h priceHeap) Len() int           { return len(h) }
-func (h priceHeap) Less(i, j int) bool { return h[i].GasPrice().Cmp(h[j].GasPrice()) < 0 }
+func (h priceHeap) Less(i, j int) bool { return h[i].CompareGasPrice(h[j]) < 0 }
 func (h priceHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
 
 func (h *priceHeap) Push(x interface{}) {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -181,6 +181,7 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 func (tx *Transaction) Data() []byte       { return common.CopyBytes(tx.data.Payload) }
 func (tx *Transaction) Gas() uint64        { return tx.data.GasLimit }
 func (tx *Transaction) GasPrice() *big.Int { return new(big.Int).Set(tx.data.Price) }
+func (tx *Transaction) CompareGasPrice(tx2 *Transaction) int { return tx.data.Price.Cmp(tx2.data.Price) }
 func (tx *Transaction) Value() *big.Int    { return new(big.Int).Set(tx.data.Amount) }
 func (tx *Transaction) Nonce() uint64      { return tx.data.AccountNonce }
 func (tx *Transaction) CheckNonce() bool   { return true }

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -233,3 +233,29 @@ func TestTransactionJSON(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkTransaction_CompareGasPrice(b *testing.B) {
+	txs := []*Transaction{
+		{data: txdata{Price: new(big.Int).SetUint64(4)},},
+		{data: txdata{Price: new(big.Int).SetUint64(125)},},
+		{data: txdata{Price: new(big.Int).SetUint64(50)},},
+		{data: txdata{Price: new(big.Int).SetUint64(4)},},
+		{data: txdata{Price: new(big.Int).SetUint64(600)},},
+		{data: txdata{Price: new(big.Int).SetUint64(11)},},
+	}
+	l := len(txs)
+	b.Run("copy", func(b *testing.B) {
+		var r int
+		for i:=0;i<b.N;i++{
+			r = txs[i%l].GasPrice().Cmp(txs[(i+1)%l].GasPrice())
+		}
+		_ = r
+	})
+	b.Run("nocopy", func(b *testing.B) {
+		var r int
+		for i:=0;i<b.N;i++{
+			r = txs[i%l].CompareGasPrice(txs[(i+1)%l])
+		}
+		_ = r
+	})
+}


### PR DESCRIPTION
I did some cpu profiling with pprof during a benchmark execution. Here is `top`:
```sh
      flat  flat%   sum%        cum   cum%
    82.36s 20.53% 20.53%     82.38s 20.53%  runtime.cgocall
    60.14s 14.99% 35.52%    124.78s 31.10%  github.com/gochain-io/gochain/core.priceHeap.Less
    29.45s  7.34% 42.86%     29.45s  7.34%  runtime.memmove
    26.44s  6.59% 49.45%     54.20s 13.51%  runtime.mallocgc
    14.87s  3.71% 53.16%     31.22s  7.78%  runtime.scanobject
    14.48s  3.61% 56.76%     14.48s  3.61%  runtime.duffcopy
    11.19s  2.79% 59.55%     18.60s  4.64%  runtime.mapaccess2
    10.57s  2.63% 62.19%     84.46s 21.05%  github.com/gochain-io/gochain/core/types.Sender
    10.05s  2.50% 64.69%     10.05s  2.50%  runtime.heapBitsForObject
     8.04s  2.00% 66.70%      8.24s  2.05%  syscall.Syscall
```

The `priceHeap.Less` method looked suspicious. It turns out it just compares two transactions' gas prices: `h[i].GasPrice().Cmp(h[j].GasPrice())`. Digging deeper, `Transaction.GasPrice` (reasonably) returns a copy of a `big.Int`, rather than its own (mutable) field value. `Less` is only inspecting, so we'd prefer direct access to the field. The new `Transaction.CompareGasPrice` method compares the unexported fields directly, reducing allocations from copying and heap garbage. `BenchmarkTransaction_CompareGasPrice` illustrates the difference:

```sh
BenchmarkTransaction_CompareGasPrice/copy-4         	10000000	       115 ns/op	      96 B/op	       2 allocs/op
BenchmarkTransaction_CompareGasPrice/nocopy-4       	50000000	        30.3 ns/op	       0 B/op	       0 allocs/op
```

This is a cpu profile after making the change:

```sh
      flat  flat%   sum%        cum   cum%
    61.18s 27.04% 27.04%     61.19s 27.05%  runtime.cgocall
    18.81s  8.31% 35.36%     35.04s 15.49%  math/big.(*Int).Cmp
    16.23s  7.17% 42.53%     16.23s  7.17%  math/big.nat.cmp
    15.29s  6.76% 49.29%     49.27s 21.78%  github.com/gochain-io/gochain/core/types.(*Transaction).CompareGasPrice
     9.62s  4.25% 53.54%      9.62s  4.25%  runtime.duffcopy
     7.70s  3.40% 56.94%     53.82s 23.79%  github.com/gochain-io/gochain/core/types.Sender
     7.32s  3.24% 60.18%     11.89s  5.26%  runtime.mapaccess2
     5.19s  2.29% 62.47%      5.34s  2.36%  syscall.Syscall
     4.92s  2.17% 64.65%     13.94s  6.16%  runtime.mallocgc
     4.27s  1.89% 66.54%     14.93s  6.60%  github.com/gochain-io/gochain/core/types.(*Transaction).Hash
```

Notably, `CompareGasPrice` is lower than `Less` was, and `runtime.mallocgc` dropped.

I assume that `runtime.cgocall` is leveldb, which we'd rather not mess with if we don't have to.