### PR TITLE
core: reduce more GasPrice allocs

### DIFF
--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -256,7 +256,7 @@ func (l *txList) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Tran
 		// Have to ensure that the new gas price is higher than the old gas
 		// price as well as checking the percentage threshold to ensure that
 		// this is accurate for low (Wei-level) gas price replacements
-		if old.GasPrice().Cmp(tx.GasPrice()) >= 0 || threshold.Cmp(tx.GasPrice()) > 0 {
+		if old.CmpGasPriceTx(tx) >= 0 || tx.CmpGasPrice(threshold) <= 0 {
 			return false, nil
 		}
 	}
@@ -368,7 +368,7 @@ func (l *txList) Flatten() types.Transactions {
 type priceHeap []*types.Transaction
 
 func (h priceHeap) Len() int           { return len(h) }
-func (h priceHeap) Less(i, j int) bool { return h[i].CompareGasPrice(h[j]) < 0 }
+func (h priceHeap) Less(i, j int) bool { return h[i].CmpGasPriceTx(h[j]) < 0 }
 func (h priceHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
 
 func (h *priceHeap) Push(x interface{}) {
@@ -437,7 +437,7 @@ func (l *txPricedList) Cap(threshold *big.Int, local *accountSet) types.Transact
 			continue
 		}
 		// Stop the discards if we've reached the threshold
-		if tx.GasPrice().Cmp(threshold) >= 0 {
+		if tx.CmpGasPrice(threshold) >= 0 {
 			save = append(save, tx)
 			break
 		}
@@ -477,7 +477,7 @@ func (l *txPricedList) Underpriced(tx *types.Transaction, local *accountSet) boo
 		return false
 	}
 	cheapest := []*types.Transaction(*l.items)[0]
-	return cheapest.GasPrice().Cmp(tx.GasPrice()) >= 0
+	return cheapest.CmpGasPriceTx(tx) >= 0
 }
 
 // Discard finds a number of most underpriced transactions, removes them from the

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -574,7 +574,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	}
 	// Drop non-local transactions under our own minimal accepted gas price
 	local = local || pool.locals.contains(from) // account may be local even if the transaction arrived from the network
-	if !local && pool.gasPrice.Cmp(tx.GasPrice()) > 0 {
+	if !local && tx.CmpGasPrice(pool.gasPrice) <= 0 {
 		return ErrUnderpriced
 	}
 	// Ensure the transaction adheres to nonce ordering

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -178,13 +178,14 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
-func (tx *Transaction) Data() []byte       { return common.CopyBytes(tx.data.Payload) }
-func (tx *Transaction) Gas() uint64        { return tx.data.GasLimit }
-func (tx *Transaction) GasPrice() *big.Int { return new(big.Int).Set(tx.data.Price) }
-func (tx *Transaction) CompareGasPrice(tx2 *Transaction) int { return tx.data.Price.Cmp(tx2.data.Price) }
-func (tx *Transaction) Value() *big.Int    { return new(big.Int).Set(tx.data.Amount) }
-func (tx *Transaction) Nonce() uint64      { return tx.data.AccountNonce }
-func (tx *Transaction) CheckNonce() bool   { return true }
+func (tx *Transaction) Data() []byte                       { return common.CopyBytes(tx.data.Payload) }
+func (tx *Transaction) Gas() uint64                        { return tx.data.GasLimit }
+func (tx *Transaction) GasPrice() *big.Int                 { return new(big.Int).Set(tx.data.Price) }
+func (tx *Transaction) CmpGasPriceTx(tx2 *Transaction) int { return tx.data.Price.Cmp(tx2.data.Price) }
+func (tx *Transaction) CmpGasPrice(i *big.Int) int         { return tx.data.Price.Cmp(i) }
+func (tx *Transaction) Value() *big.Int                    { return new(big.Int).Set(tx.data.Amount) }
+func (tx *Transaction) Nonce() uint64                      { return tx.data.AccountNonce }
+func (tx *Transaction) CheckNonce() bool                   { return true }
 
 // To returns the recipient address of the transaction.
 // It returns nil if the transaction is a contract creation.

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -234,27 +234,27 @@ func TestTransactionJSON(t *testing.T) {
 	}
 }
 
-func BenchmarkTransaction_CompareGasPrice(b *testing.B) {
+func BenchmarkTransaction_CmpGasPriceTx(b *testing.B) {
 	txs := []*Transaction{
-		{data: txdata{Price: new(big.Int).SetUint64(4)},},
-		{data: txdata{Price: new(big.Int).SetUint64(125)},},
-		{data: txdata{Price: new(big.Int).SetUint64(50)},},
-		{data: txdata{Price: new(big.Int).SetUint64(4)},},
-		{data: txdata{Price: new(big.Int).SetUint64(600)},},
-		{data: txdata{Price: new(big.Int).SetUint64(11)},},
+		{data: txdata{Price: new(big.Int).SetUint64(4)}},
+		{data: txdata{Price: new(big.Int).SetUint64(125)}},
+		{data: txdata{Price: new(big.Int).SetUint64(50)}},
+		{data: txdata{Price: new(big.Int).SetUint64(4)}},
+		{data: txdata{Price: new(big.Int).SetUint64(600)}},
+		{data: txdata{Price: new(big.Int).SetUint64(11)}},
 	}
 	l := len(txs)
 	b.Run("copy", func(b *testing.B) {
 		var r int
-		for i:=0;i<b.N;i++{
+		for i := 0; i < b.N; i++ {
 			r = txs[i%l].GasPrice().Cmp(txs[(i+1)%l].GasPrice())
 		}
 		_ = r
 	})
 	b.Run("nocopy", func(b *testing.B) {
 		var r int
-		for i:=0;i<b.N;i++{
-			r = txs[i%l].CompareGasPrice(txs[(i+1)%l])
+		for i := 0; i < b.N; i++ {
+			r = txs[i%l].CmpGasPriceTx(txs[(i+1)%l])
 		}
 		_ = r
 	})

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -156,7 +156,7 @@ type transactionsByGasPrice []*types.Transaction
 
 func (t transactionsByGasPrice) Len() int           { return len(t) }
 func (t transactionsByGasPrice) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
-func (t transactionsByGasPrice) Less(i, j int) bool { return t[i].GasPrice().Cmp(t[j].GasPrice()) < 0 }
+func (t transactionsByGasPrice) Less(i, j int) bool { return t[i].CmpGasPriceTx(t[j]) < 0 }
 
 // getBlockPrices calculates the lowest transaction gas price in a given block
 // and sends it to the result channel. If the block is empty, price is nil.


### PR DESCRIPTION
Follow up from #31.  Use the new method (renamed) in a few more places, add another similar method, and `go fmt`.