### PR TITLE
core: reduce allocs; increase default pool sizes

### DIFF
--- a/core/tx_list_test.go
+++ b/core/tx_list_test.go
@@ -35,7 +35,7 @@ func TestStrictTxListAdd(t *testing.T) {
 		txs[i] = transaction(uint64(i), 0, key)
 	}
 	// Insert the transactions in a random order
-	list := newTxList(true)
+	list := newTxList(true, 1024)
 	for _, v := range rand.Perm(len(txs)) {
 		list.Add(txs[v], DefaultTxPoolConfig.PriceBump)
 	}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -335,7 +335,7 @@ func (s Transactions) GetRlp(i int) []byte {
 func TxDifference(a, b Transactions) (keep Transactions) {
 	keep = make(Transactions, 0, len(a))
 
-	remove := make(map[common.Hash]struct{})
+	remove := make(map[common.Hash]struct{}, len(b))
 	for _, tx := range b {
 		remove[tx.Hash()] = struct{}{}
 	}


### PR DESCRIPTION
This PR proposes some changes to reduce allocations based on some pprof heap analysis.  Benchmark transaction ingestion *seems* smoother, but is still very unstable.  Pprof heap info does seem to be improved though - e.g. most of the top heap pressure is only from leveldb instead of growing these tx pool maps.