### PR TITLE
core: replace TxDifference with optimized inlined version

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -331,24 +331,6 @@ func (s Transactions) GetRlp(i int) []byte {
 	return enc
 }
 
-// TxDifference returns a new set t which is the difference between a to b.
-func TxDifference(a, b Transactions) (keep Transactions) {
-	keep = make(Transactions, 0, len(a))
-
-	remove := make(map[common.Hash]struct{}, len(b))
-	for _, tx := range b {
-		remove[tx.Hash()] = struct{}{}
-	}
-
-	for _, tx := range a {
-		if _, ok := remove[tx.Hash()]; !ok {
-			keep = append(keep, tx)
-		}
-	}
-
-	return keep
-}
-
 // TxByNonce implements the sort interface to allow sorting a list of transactions
 // by their nonces. This is usually only useful for sorting transactions from a
 // single account, otherwise a nonce comparison doesn't make much sense.

--- a/rlp/typecache.go
+++ b/rlp/typecache.go
@@ -65,8 +65,9 @@ func cachedTypeInfo(typ reflect.Type, tags tags) (*typeinfo, error) {
 	}
 	// not in the cache, need to generate info for this type.
 	typeCacheMutex.Lock()
-	defer typeCacheMutex.Unlock()
-	return cachedTypeInfo1(typ, tags)
+	info, err := cachedTypeInfo1(typ, tags)
+	typeCacheMutex.Unlock()
+	return info, err
 }
 
 func cachedTypeInfo1(typ reflect.Type, tags tags) (*typeinfo, error) {


### PR DESCRIPTION
Based on tracing,`TxPool.reset()` is pretty costly, and in the critical path.