### PR TITLE
core/types: (*Block).String() - print len(txs), instead of every tx

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -413,12 +413,11 @@ func (b *Block) String() string {
 	str := fmt.Sprintf(`Block(#%v): Size: %v {
 MinerHash: %x
 %v
-Transactions:
-%v
+Transactions: %d
 Uncles:
 %v
 }
-`, b.Number(), b.Size(), b.header.HashNoNonce(), b.header, b.transactions, b.uncles)
+`, b.Number(), b.Size(), b.header.HashNoNonce(), b.header, len(b.transactions), b.uncles)
 	return str
 }
 


### PR DESCRIPTION
When `Bad uncle found and will be removed` (on the critical path for a worker) the block is logged to trace, which included printing every tx in the block (even if trace is off at the time). With thousands of txs, this is slow and not even useful. Just log the number of txs instead.