### PR TITLE
core: recycle int pools across multiple invocations to reduce garbage

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -86,7 +86,7 @@ func (b *BlockGen) AddTx(tx *types.Transaction) {
 		b.SetCoinbase(common.Address{})
 	}
 	b.statedb.Prepare(tx.Hash(), common.Hash{}, len(b.txs))
-	receipt, _, err := ApplyTransaction(b.config, nil, &b.header.Coinbase, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, vm.Config{})
+	receipt, _, err := ApplyTransaction(b.config, nil, &b.header.Coinbase, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, vm.Config{}, vm.NewIntPool())
 	if err != nil {
 		panic(err)
 	}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -111,9 +111,14 @@ type EVM struct {
 	callGasTemp uint64
 }
 
-// NewEVM retutrns a new EVM . The returned EVM is not thread safe and should
+// NewEVM returns a new EVM . The returned EVM is not thread safe and should
 // only ever be used *once*.
 func NewEVM(ctx Context, statedb StateDB, chainConfig *params.ChainConfig, vmConfig Config) *EVM {
+	return NewEVMPool(ctx, statedb, chainConfig, vmConfig, NewIntPool())
+}
+
+// NewEVMPool is like NewEVM, but also takes an IntPool, which can be recycled across multiple (serial) invocations.
+func NewEVMPool(ctx Context, statedb StateDB, chainConfig *params.ChainConfig, vmConfig Config, intPool *IntPool) *EVM {
 	evm := &EVM{
 		Context:     ctx,
 		StateDB:     statedb,
@@ -121,8 +126,7 @@ func NewEVM(ctx Context, statedb StateDB, chainConfig *params.ChainConfig, vmCon
 		chainConfig: chainConfig,
 		chainRules:  chainConfig.Rules(ctx.BlockNumber),
 	}
-
-	evm.interpreter = NewInterpreter(evm, vmConfig)
+	evm.interpreter = NewInterpreter(evm, vmConfig, intPool)
 	return evm
 }
 

--- a/core/vm/int_pool_verifier.go
+++ b/core/vm/int_pool_verifier.go
@@ -22,7 +22,7 @@ import "fmt"
 
 const verifyPool = true
 
-func verifyIntegerPool(ip *intPool) {
+func verifyIntegerPool(ip *IntPool) {
 	for i, item := range ip.pool.data {
 		if item.Cmp(checkVal) != 0 {
 			panic(fmt.Sprintf("%d'th item failed aggressive pool check. Value was modified", i))

--- a/core/vm/int_pool_verifier_empty.go
+++ b/core/vm/int_pool_verifier_empty.go
@@ -20,4 +20,4 @@ package vm
 
 const verifyPool = false
 
-func verifyIntegerPool(ip *intPool) {}
+func verifyIntegerPool(ip *IntPool) {}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -55,14 +55,14 @@ type Interpreter struct {
 	evm      *EVM
 	cfg      Config
 	gasTable params.GasTable
-	intPool  *intPool
+	intPool  *IntPool
 
 	readOnly   bool   // Whether to throw on stateful modifications
 	returnData []byte // Last CALL's return data for subsequent reuse
 }
 
 // NewInterpreter returns a new instance of the Interpreter.
-func NewInterpreter(evm *EVM, cfg Config) *Interpreter {
+func NewInterpreter(evm *EVM, cfg Config, intPool *IntPool) *Interpreter {
 	// We use the STOP instruction whether to see
 	// the jump table was initialised. If it was not
 	// we'll set the default jump table.
@@ -81,7 +81,7 @@ func NewInterpreter(evm *EVM, cfg Config) *Interpreter {
 		evm:      evm,
 		cfg:      cfg,
 		gasTable: evm.ChainConfig().GasTable(evm.BlockNumber),
-		intPool:  newIntPool(),
+		intPool:  intPool,
 	}
 }
 

--- a/core/vm/intpool.go
+++ b/core/vm/intpool.go
@@ -22,23 +22,23 @@ var checkVal = big.NewInt(-42)
 
 const poolLimit = 256
 
-// intPool is a pool of big integers that
+// IntPool is a pool of big integers that
 // can be reused for all big.Int operations.
-type intPool struct {
+type IntPool struct {
 	pool *Stack
 }
 
-func newIntPool() *intPool {
-	return &intPool{pool: newstack()}
+func NewIntPool() *IntPool {
+	return &IntPool{pool: newstack()}
 }
 
-func (p *intPool) get() *big.Int {
+func (p *IntPool) get() *big.Int {
 	if p.pool.len() > 0 {
 		return p.pool.pop()
 	}
 	return new(big.Int)
 }
-func (p *intPool) put(is ...*big.Int) {
+func (p *IntPool) put(is ...*big.Int) {
 	if len(p.pool.data) > poolLimit {
 		return
 	}

--- a/core/vm/stack.go
+++ b/core/vm/stack.go
@@ -60,7 +60,7 @@ func (st *Stack) swap(n int) {
 	st.data[st.len()-n], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-n]
 }
 
-func (st *Stack) dup(pool *intPool, n int) {
+func (st *Stack) dup(pool *IntPool, n int) {
 	st.push(pool.get().Set(st.data[st.len()-n]))
 }
 


### PR DESCRIPTION
In two places we iterate over every tx in a block, and create a new `EVM/Interpreter` for each one. Each new `vm.EVM/Interpreter` was creating a new `intPool`. Now both loops first create a single `IntPool` and recycle it on each invocation. 