### PR TITLE
reduce allocs by using optimized single use Keccak256/512 Hash

### DIFF
--- a/accounts/abi/bind/topics.go
+++ b/accounts/abi/bind/topics.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/gochain-io/gochain/accounts/abi"
 	"github.com/gochain-io/gochain/common"
-	"github.com/gochain-io/gochain/crypto"
+	"github.com/gochain-io/gochain/crypto/sha3"
 )
 
 // makeTopics converts a filter query argument list into a filter topic set.
@@ -72,11 +72,9 @@ func makeTopics(query ...[]interface{}) ([][]common.Hash, error) {
 				blob := new(big.Int).SetUint64(rule).Bytes()
 				copy(topic[common.HashLength-len(blob):], blob)
 			case string:
-				hash := crypto.Keccak256Hash([]byte(rule))
-				copy(topic[:], hash[:])
+				sha3.Keccak256(topic[:32], []byte(rule))
 			case []byte:
-				hash := crypto.Keccak256Hash(rule)
-				copy(topic[:], hash[:])
+				sha3.Keccak256(topic[:32], rule)
 
 			default:
 				// Attempt to generate the topic from funky types

--- a/accounts/abi/event.go
+++ b/accounts/abi/event.go
@@ -53,5 +53,5 @@ func (e Event) Id() common.Hash {
 		types[i] = input.Type.String()
 		i++
 	}
-	return common.BytesToHash(crypto.Keccak256([]byte(fmt.Sprintf("%v(%v)", e.Name, strings.Join(types, ",")))))
+	return crypto.Keccak256Hash([]byte(fmt.Sprintf("%v(%v)", e.Name, strings.Join(types, ","))))
 }

--- a/common/types.go
+++ b/common/types.go
@@ -165,9 +165,8 @@ func (a Address) Hash() Hash    { return BytesToHash(a[:]) }
 // Hex returns an EIP55-compliant hex string representation of the address.
 func (a Address) Hex() string {
 	unchecksummed := hex.EncodeToString(a[:])
-	sha := sha3.NewKeccak256()
-	sha.Write([]byte(unchecksummed))
-	hash := sha.Sum(nil)
+	var hash Hash
+	sha3.Keccak256(hash[:], []byte(unchecksummed))
 
 	result := []byte(unchecksummed)
 	for i := 0; i < len(result); i++ {

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -191,8 +191,9 @@ func ecrecover(header *types.Header, sigcache *lru.ARCCache) (common.Address, er
 	if err != nil {
 		return common.Address{}, err
 	}
+	h := crypto.Keccak256Hash(pubkey[1:])
 	var signer common.Address
-	copy(signer[:], crypto.Keccak256(pubkey[1:])[12:])
+	copy(signer[:], h[12:])
 
 	sigcache.Add(hash, signer)
 	return signer, nil

--- a/consensus/ethash/algorithm.go
+++ b/consensus/ethash/algorithm.go
@@ -295,7 +295,7 @@ func hashimoto(hash []byte, nonce uint64, size uint64, lookup func(index uint32)
 	copy(seed, hash)
 	binary.LittleEndian.PutUint64(seed[32:], nonce)
 
-	seed = crypto.Keccak512(seed)
+	seed = sha3.Keccak512(seed)
 	seedHead := binary.LittleEndian.Uint32(seed)
 
 	// Start the mix with replicated seed

--- a/core/bloombits/matcher.go
+++ b/core/bloombits/matcher.go
@@ -36,11 +36,11 @@ type bloomIndexes [3]uint
 
 // calcBloomIndexes returns the bloom filter bit indexes belonging to the given key.
 func calcBloomIndexes(b []byte) bloomIndexes {
-	b = crypto.Keccak256(b)
+	h := crypto.Keccak256Hash(b)
 
 	var idxs bloomIndexes
 	for i := 0; i < len(idxs); i++ {
-		idxs[i] = (uint(b[2*i])<<8)&2047 + uint(b[2*i+1])
+		idxs[i] = (uint(h[2*i])<<8)&2047 + uint(h[2*i+1])
 	}
 	return idxs
 }

--- a/core/types/bloom9.go
+++ b/core/types/bloom9.go
@@ -113,13 +113,13 @@ func LogsBloom(logs []*Log) *big.Int {
 }
 
 func bloom9(b []byte) *big.Int {
-	b = crypto.Keccak256(b[:])
+	h := crypto.Keccak256Hash(b)
 
 	r := new(big.Int)
 
 	for i := 0; i < 6; i += 2 {
 		t := big.NewInt(1)
-		b := (uint(b[i+1]) + (uint(b[i]) << 8)) & 2047
+		b := (uint(h[i+1]) + (uint(h[i]) << 8)) & 2047
 		r.Or(r, t.Lsh(t, b))
 	}
 

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -98,7 +98,11 @@ func (c *ecrecover) Run(input []byte) ([]byte, error) {
 	}
 
 	// the first byte of pubkey is bitcoin heritage
-	return common.LeftPadBytes(crypto.Keccak256(pubKey[1:])[12:], 32), nil
+	h := crypto.Keccak256Hash(pubKey[1:])
+	for i := 0; i < 12; i++ {
+		h[i] = 0
+	}
+	return h[:], nil
 }
 
 // SHA256 implemented as a native contract.

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -305,13 +305,13 @@ func opMulmod(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *S
 func opSha3(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	offset, size := stack.pop(), stack.pop()
 	data := memory.Get(offset.Int64(), size.Int64())
-	hash := crypto.Keccak256(data)
+	hash := crypto.Keccak256Hash(data)
 
 	if evm.vmConfig.EnablePreimageRecording {
-		evm.StateDB.AddPreimage(common.BytesToHash(hash), data)
+		evm.StateDB.AddPreimage(hash, data)
 	}
 
-	stack.push(new(big.Int).SetBytes(hash))
+	stack.push(new(big.Int).SetBytes(hash[:]))
 
 	evm.interpreter.intPool.put(offset, size)
 	return nil, nil

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -83,7 +83,7 @@ func setDefaults(cfg *Config) {
 	}
 	if cfg.GetHashFn == nil {
 		cfg.GetHashFn = func(n uint64) common.Hash {
-			return common.BytesToHash(crypto.Keccak256([]byte(new(big.Int).SetUint64(n).String())))
+			return crypto.Keccak256Hash([]byte(new(big.Int).SetUint64(n).String()))
 		}
 	}
 }

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -40,38 +40,28 @@ var (
 )
 
 // Keccak256 calculates and returns the Keccak256 hash of the input data.
+// Consider using sha3.Keccak256 directly instead.
 func Keccak256(data ...[]byte) []byte {
-	d := sha3.NewKeccak256()
-	for _, b := range data {
-		d.Write(b)
-	}
-	return d.Sum(nil)
+	var h common.Hash
+	sha3.Keccak256(h[:], data...)
+	return h[:]
 }
 
 // Keccak256Hash calculates and returns the Keccak256 hash of the input data,
 // converting it to an internal Hash data structure.
+// Consider using sha3.Keccak256 directly instead.
 func Keccak256Hash(data ...[]byte) (h common.Hash) {
-	d := sha3.NewKeccak256()
-	for _, b := range data {
-		d.Write(b)
-	}
-	d.Sum(h[:0])
+	sha3.Keccak256(h[:], data...)
 	return h
-}
-
-// Keccak512 calculates and returns the Keccak512 hash of the input data.
-func Keccak512(data ...[]byte) []byte {
-	d := sha3.NewKeccak512()
-	for _, b := range data {
-		d.Write(b)
-	}
-	return d.Sum(nil)
 }
 
 // Creates an ethereum address given the bytes and the nonce
 func CreateAddress(b common.Address, nonce uint64) common.Address {
 	data, _ := rlp.EncodeToBytes([]interface{}{b, nonce})
-	return common.BytesToAddress(Keccak256(data)[12:])
+	var a common.Address
+	h := Keccak256Hash(data)
+	copy(a[:], h[12:])
+	return a
 }
 
 // ToECDSA creates a private key with the given D value.
@@ -193,7 +183,10 @@ func ValidateSignatureValues(v byte, r, s *big.Int, homestead bool) bool {
 
 func PubkeyToAddress(p ecdsa.PublicKey) common.Address {
 	pubBytes := FromECDSAPub(&p)
-	return common.BytesToAddress(Keccak256(pubBytes[1:])[12:])
+	var a common.Address
+	h := Keccak256Hash(pubBytes[1:])
+	copy(a[:], h[12:])
+	return a
 }
 
 func zeroBytes(bytes []byte) {

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -49,13 +49,6 @@ func TestToECDSAErrors(t *testing.T) {
 	}
 }
 
-func BenchmarkSha3(b *testing.B) {
-	a := []byte("hello world")
-	for i := 0; i < b.N; i++ {
-		Keccak256(a)
-	}
-}
-
 func TestSign(t *testing.T) {
 	key, _ := HexToECDSA(testPrivHex)
 	addr := common.HexToAddress(testAddrHex)

--- a/crypto/sha3/hashes.go
+++ b/crypto/sha3/hashes.go
@@ -15,8 +15,32 @@ import (
 // NewKeccak256 creates a new Keccak-256 hash.
 func NewKeccak256() hash.Hash { return &state{rate: 136, outputLen: 32, dsbyte: 0x01} }
 
+// Keccak256 is optimized for cases that call Sum() just once. When h is 32
+// bytes it is equivalent to calling NewKeccak256() and using the Write() and
+// Sum() hash.Hash interface methods, but avoids the extra allocations in
+// (*state).Sum(), which copies the internal state for continued use. This copy
+// is unnecessary when the hash.Hash is discarded after calling Sum().
+func Keccak256(h []byte, data ...[]byte) {
+	s := &state{rate: 136, outputLen: 32, dsbyte: 0x01}
+	for _, b := range data {
+		s.Write(b)
+	}
+	s.Read(h)
+}
+
 // NewKeccak512 creates a new Keccak-512 hash.
 func NewKeccak512() hash.Hash { return &state{rate: 72, outputLen: 64, dsbyte: 0x01} }
+
+// Keccack512 is an optimized alternative to NewKeccak512/Write/Sum, like Keccack256.
+func Keccak512(data ...[]byte) []byte {
+	var h [64]byte
+	s := &state{rate: 72, outputLen: 64, dsbyte: 0x01}
+	for _, b := range data {
+		s.Write(b)
+	}
+	s.Read(h[:])
+	return h[:]
+}
 
 // New224 creates a new SHA3-224 hash.
 // Its generic security strength is 224 bits against preimage attacks,

--- a/crypto/sha3/hashes_test.go
+++ b/crypto/sha3/hashes_test.go
@@ -1,0 +1,76 @@
+package sha3
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestKeccak256(t *testing.T) {
+	for _, data := range [][]byte{
+		[]byte("hello world"),
+		[]byte("hello world hello world hello world hello world hello world hello world"),
+		[]byte("0123456789asdfjkl;"),
+	} {
+		h := NewKeccak256()
+		h.Write(data)
+		a := h.Sum(nil)
+		var b [32]byte
+		Keccak256(b[:], data)
+		if !bytes.Equal(a, b[:]) {
+			t.Errorf("%q: expected %X got %X", data, a, b)
+		}
+	}
+}
+
+func BenchmarkKeccak256(b *testing.B) {
+	a := []byte("hello world hello world hello world hello world hello world hello world")
+	b.Run("unoptimized", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			h := NewKeccak256()
+			h.Write(a)
+			_ = h.Sum(nil)
+		}
+	})
+	b.Run("optimized", func(b *testing.B) {
+		var hash [32]byte
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			Keccak256(hash[:], a)
+		}
+	})
+}
+
+func TestKeccak512(t *testing.T) {
+	for _, data := range [][]byte{
+		[]byte("hello world"),
+		[]byte("hello world hello world hello world hello world hello world hello world"),
+		[]byte("0123456789asdfjkl;"),
+	} {
+		h := NewKeccak512()
+		h.Write(data)
+		a := h.Sum(nil)
+		b := Keccak512(data)
+		if !bytes.Equal(a, b) {
+			t.Errorf("%q: expected %X got %X", data, a, b)
+		}
+	}
+}
+
+func BenchmarkKeccak512(b *testing.B) {
+	a := []byte("hello world hello world hello world hello world hello world hello world")
+	b.Run("unoptimized", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			h := NewKeccak512()
+			h.Write(a)
+			_ = h.Sum(nil)
+		}
+	})
+	b.Run("optimized", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = Keccak512(a)
+		}
+	})
+}

--- a/p2p/discover/udp.go
+++ b/p2p/discover/udp.go
@@ -553,8 +553,8 @@ func decodePacket(buf []byte) (packet, NodeID, []byte, error) {
 		return nil, NodeID{}, nil, errPacketTooSmall
 	}
 	hash, sig, sigdata := buf[:macSize], buf[macSize:headSize], buf[headSize:]
-	shouldhash := crypto.Keccak256(buf[macSize:])
-	if !bytes.Equal(hash, shouldhash) {
+	shouldhash := crypto.Keccak256Hash(buf[macSize:])
+	if !bytes.Equal(hash, shouldhash[:]) {
 		return nil, NodeID{}, nil, errBadHash
 	}
 	fromID, err := recoverNodeID(crypto.Keccak256(buf[headSize:]), sig)

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -427,7 +427,8 @@ func (h *encHandshake) makeAuthResp() (msg *authRespV4, err error) {
 func (msg *authMsgV4) sealPlain(h *encHandshake) ([]byte, error) {
 	buf := make([]byte, authMsgLen)
 	n := copy(buf, msg.Signature[:])
-	n += copy(buf[n:], crypto.Keccak256(exportPubkey(&h.randomPrivKey.PublicKey)))
+	sha3.Keccak256(buf[n:n+32], exportPubkey(&h.randomPrivKey.PublicKey))
+	n += 32
 	n += copy(buf[n:], msg.InitiatorPubkey[:])
 	n += copy(buf[n:], msg.Nonce[:])
 	buf[n] = 0 // token-flag

--- a/tests/vm_test_util.go
+++ b/tests/vm_test_util.go
@@ -148,5 +148,5 @@ func (t *VMTest) newEVM(statedb *state.StateDB, vmconfig vm.Config) *vm.EVM {
 }
 
 func vmTestBlockHash(n uint64) common.Hash {
-	return common.BytesToHash(crypto.Keccak256([]byte(big.NewInt(int64(n)).String())))
+	return crypto.Keccak256Hash([]byte(big.NewInt(int64(n)).String()))
 }

--- a/whisper/whisperv6/envelope.go
+++ b/whisper/whisperv6/envelope.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gochain-io/gochain/common/math"
 	"github.com/gochain-io/gochain/crypto"
 	"github.com/gochain-io/gochain/crypto/ecies"
+	"github.com/gochain-io/gochain/crypto/sha3"
 	"github.com/gochain-io/gochain/rlp"
 )
 
@@ -93,8 +94,7 @@ func (e *Envelope) Seal(options *MessageParams) error {
 	}
 
 	buf := make([]byte, 64)
-	h := crypto.Keccak256(e.rlpWithoutNonce())
-	copy(buf[:32], h)
+	sha3.Keccak256(buf[:32], e.rlpWithoutNonce())
 
 	finish := time.Now().Add(time.Duration(options.WorkTime) * time.Second).UnixNano()
 	for nonce := uint64(0); time.Now().UnixNano() < finish; {
@@ -130,8 +130,7 @@ func (e *Envelope) PoW() float64 {
 
 func (e *Envelope) calculatePoW(diff uint32) {
 	buf := make([]byte, 64)
-	h := crypto.Keccak256(e.rlpWithoutNonce())
-	copy(buf[:32], h)
+	sha3.Keccak256(buf[:32], e.rlpWithoutNonce())
 	binary.BigEndian.PutUint64(buf[56:], e.Nonce)
 	d := new(big.Int).SetBytes(crypto.Keccak256(buf))
 	firstBit := math.FirstBitSet(d)


### PR DESCRIPTION
This PR aims to speed up and reduce garbage, and allocations in general, from hashing. The main change is optimized forms of [`Keccak256/512`](https://github.com/gochain-io/gochain/pull/59/files#diff-b55554026d6bc2ea37a914b28b4729b2R23) for one-time usages. Some additional tweaks were made at call sites as well to reduce copying and allocations. These new benchmarks illustrate the difference:

```sh
BenchmarkKeccak256/unoptimized-4         	 2000000	       921 ns/op	     960 B/op	       4 allocs/op
BenchmarkKeccak256/optimized-4           	 2000000	       729 ns/op	     448 B/op	       1 allocs/op
BenchmarkKeccak512/unoptimized-4         	 2000000	       884 ns/op	    1024 B/op	       4 allocs/op
BenchmarkKeccak512/optimized-4           	 2000000	       691 ns/op	     512 B/op	       2 allocs/op

```