### PR TITLE
rlp: SliceEncoder/Decoder support for more efficient ReceiptForStorage serialization

### DIFF
--- a/core/database_util.go
+++ b/core/database_util.go
@@ -239,16 +239,12 @@ func GetBlockReceipts(db DatabaseReader, hash common.Hash, number uint64) types.
 	if len(data) == 0 {
 		return nil
 	}
-	storageReceipts := []*types.ReceiptForStorage{}
+	storageReceipts := types.ReceiptsForStorage{}
 	if err := rlp.DecodeBytes(data, &storageReceipts); err != nil {
 		log.Error("Invalid receipt array RLP", "hash", hash, "err", err)
 		return nil
 	}
-	receipts := make(types.Receipts, len(storageReceipts))
-	for i, receipt := range storageReceipts {
-		receipts[i] = (*types.Receipt)(receipt)
-	}
-	return receipts
+	return types.Receipts(storageReceipts)
 }
 
 // GetTxLookupEntry retrieves the positional metadata associated with a transaction
@@ -443,11 +439,7 @@ func WriteBlock(db ethdb.Putter, block *types.Block) error {
 // rescheduling dropped transactions.
 func WriteBlockReceipts(db ethdb.Putter, hash common.Hash, number uint64, receipts types.Receipts) error {
 	// Convert the receipts into their storage form and serialize them
-	storageReceipts := make([]*types.ReceiptForStorage, len(receipts))
-	for i, receipt := range receipts {
-		storageReceipts[i] = (*types.ReceiptForStorage)(receipt)
-	}
-	bytes, err := rlp.EncodeToBytes(storageReceipts)
+	bytes, err := rlp.EncodeToBytes((types.ReceiptsForStorage)(receipts))
 	if err != nil {
 		return err
 	}

--- a/core/types/log.go
+++ b/core/types/log.go
@@ -99,6 +99,22 @@ func (l *Log) String() string {
 	return fmt.Sprintf(`log: %x %x %x %x %d %x %d`, l.Address, l.Topics, l.Data, l.TxHash, l.TxIndex, l.BlockHash, l.Index)
 }
 
+// LogsForStorage RLP encodes as []*LogForStorage.
+type LogsForStorage []*Log
+
+func (l LogsForStorage) EncodeRLPElem(i int, w io.Writer) error {
+	return rlp.Encode(w, (*LogForStorage)(l[i]))
+}
+
+func (l *LogsForStorage) DecodeRLPElem(s *rlp.Stream) error {
+	var log LogForStorage
+	if err := s.Decode(&log); err != nil {
+		return err
+	}
+	*l = append(*l, (*Log)(&log))
+	return nil
+}
+
 // LogForStorage is a wrapper around a Log that flattens and parses the entire content of
 // a log including non-consensus fields.
 type LogForStorage Log

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -1,0 +1,77 @@
+package types
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/gochain-io/gochain/common"
+	"github.com/gochain-io/gochain/rlp"
+)
+
+func TestReceiptsForStorage_EncodeRLP(t *testing.T) {
+	receipt1 := &Receipt{
+		Status:            ReceiptStatusFailed,
+		CumulativeGasUsed: 1,
+		Logs: []*Log{
+			{Address: common.BytesToAddress([]byte{0x11})},
+			{Address: common.BytesToAddress([]byte{0x01, 0x11})},
+		},
+		TxHash:          common.BytesToHash([]byte{0x11, 0x11}),
+		ContractAddress: common.BytesToAddress([]byte{0x01, 0x11, 0x11}),
+		GasUsed:         111111,
+	}
+	receipt2 := &Receipt{
+		PostState:         common.Hash{2}.Bytes(),
+		CumulativeGasUsed: 2,
+		Logs: []*Log{
+			{Address: common.BytesToAddress([]byte{0x22})},
+			{Address: common.BytesToAddress([]byte{0x02, 0x22})},
+		},
+		TxHash:          common.BytesToHash([]byte{0x22, 0x22}),
+		ContractAddress: common.BytesToAddress([]byte{0x02, 0x22, 0x22}),
+		GasUsed:         222222,
+	}
+
+	normal := []*ReceiptForStorage{
+		(*ReceiptForStorage)(receipt1),
+		(*ReceiptForStorage)(receipt2),
+	}
+	normalBytes, err := rlp.EncodeToBytes(normal)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	custom := ReceiptsForStorage{receipt1, receipt2}
+	customBytes, err := rlp.EncodeToBytes(custom)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(normalBytes, customBytes) {
+		t.Errorf("expected %x but got %x", normalBytes, customBytes)
+	}
+
+	var normalDec []*ReceiptForStorage
+	if err := rlp.DecodeBytes(normalBytes, &normalDec); err != nil {
+		t.Fatal(err)
+	}
+
+	var customDec ReceiptsForStorage
+	if err := rlp.DecodeBytes(normalBytes, &customDec); err != nil {
+		t.Fatal(err)
+	}
+	if len(normalDec) != len(customDec) {
+		t.Errorf("expected %v but got %v", normalDec, customDec)
+	} else {
+		for i := range normalDec {
+			normal := (*Receipt)(normalDec[i])
+			custom := customDec[i]
+			if !reflect.DeepEqual(*normal, *custom) {
+				t.Errorf("expected %v but got %v", normalDec, customDec)
+				break
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
`Receipt` serialization involved copying large slices of `*Receipt` to `*ReceiptForStorage` and vice versa, because although the element value types are convertible (`(Receipt)(ReceiptForStorage{})`), the slice types are not (`([]*Receipt)([]*ReceiptForStorage{})`). This change extends the `rlp` package with `SliceEncoder` and `SliceDecoder` interfaces, so that we can define two new types, `ReceiptsForStorage` and `LogsForStorage`, which can be converted from `[]*Receipt` and `[]*Log`but which serialize as `[]*ReceiptForStorage` and `[]*LogForStorage`. This allows replacement of copy loops with simple type conversions.