### PR TITLE
core: reduce db key allocations

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -544,7 +544,7 @@ func (bc *BlockChain) HasBlock(hash common.Hash, number uint64) bool {
 	if bc.blockCache.Contains(hash) {
 		return true
 	}
-	ok, _ := bc.db.Has(blockBodyKey(hash, number))
+	ok, _ := bc.db.Has(numHashKey(bodyPrefix, number, hash))
 	return ok
 }
 

--- a/core/database_util_test.go
+++ b/core/database_util_test.go
@@ -386,3 +386,19 @@ func TestBlockReceiptStorage(t *testing.T) {
 		t.Fatalf("deleted receipts returned: %v", rs)
 	}
 }
+
+func BenchmarkNumHashKey(b *testing.B) {
+	prefix := []byte("h")
+	b.Run("unoptimized", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = append(append(prefix, encodeBlockNumber(123456789)...), common.Hash{}.Bytes()...)
+		}
+	})
+	b.Run("optimized", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = numHashKey('h', 123456789, common.Hash{})
+		}
+	})
+}

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -366,7 +366,7 @@ func (hc *HeaderChain) HasHeader(hash common.Hash, number uint64) bool {
 	if hc.numberCache.Contains(hash) || hc.headerCache.Contains(hash) {
 		return true
 	}
-	ok, _ := hc.chainDb.Has(headerKey(hash, number))
+	ok, _ := hc.chainDb.Has(numHashKey(headerPrefix, number, hash))
 	return ok
 }
 


### PR DESCRIPTION
Minor db key improvements to reduce allocations. For example:
```
BenchmarkNumHashKey/unoptimized-4         	20000000	        92.0 ns/op	      64 B/op	       2 allocs/op
BenchmarkNumHashKey/optimized-4           	20000000	        51.4 ns/op	      48 B/op	       1 allocs/op
```