### PR TITLE
rlp: Stream sync.Pool

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -380,7 +380,7 @@ func DeveloperGenesisBlock(period uint64, faucet common.Address) *Genesis {
 
 func decodePrealloc(data string) GenesisAlloc {
 	var p []struct{ Addr, Balance *big.Int }
-	if err := rlp.NewStream(strings.NewReader(data), 0).Decode(&p); err != nil {
+	if err := rlp.Decode(strings.NewReader(data), &p); err != nil {
 		panic(err)
 	}
 	ga := make(GenesisAlloc, len(p))

--- a/core/tx_journal.go
+++ b/core/tx_journal.go
@@ -74,6 +74,7 @@ func (journal *txJournal) load(add func(types.Transactions) []error) error {
 
 	// Inject all transactions from the journal into the pool
 	stream := rlp.NewStream(input, 0)
+	defer rlp.Discard(stream)
 	total, dropped := 0, 0
 
 	var failure error

--- a/eth/api.go
+++ b/eth/api.go
@@ -260,6 +260,7 @@ func (api *PrivateAdminAPI) ImportChain(file string) (bool, error) {
 
 	// Run actual the import in pre-configured batches
 	stream := rlp.NewStream(reader, 0)
+	defer rlp.Discard(stream)
 
 	blocks, index := make([]*types.Block, 0, 2500), 0
 	for batch := 0; ; batch++ {

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -466,6 +466,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 	case msg.Code == GetBlockBodiesMsg:
 		// Decode the retrieval message
 		msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
+		defer rlp.Discard(msgStream)
 		if _, err := msgStream.List(); err != nil {
 			return err
 		}
@@ -519,6 +520,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 	case p.version >= eth63 && msg.Code == GetNodeDataMsg:
 		// Decode the retrieval message
 		msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
+		defer rlp.Discard(msgStream)
 		if _, err := msgStream.List(); err != nil {
 			return err
 		}
@@ -557,6 +559,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 	case p.version >= eth63 && msg.Code == GetReceiptsMsg:
 		// Decode the retrieval message
 		msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
+		defer rlp.Discard(msgStream)
 		if _, err := msgStream.List(); err != nil {
 			return err
 		}

--- a/p2p/discover/udp.go
+++ b/p2p/discover/udp.go
@@ -574,9 +574,7 @@ func decodePacket(buf []byte) (packet, NodeID, []byte, error) {
 	default:
 		return nil, fromID, hash, fmt.Errorf("unknown type: %d", ptype)
 	}
-	s := rlp.NewStream(bytes.NewReader(sigdata[1:]), 0)
-	err = s.Decode(req)
-	return req, fromID, hash, err
+	return req, fromID, hash, rlp.Decode(bytes.NewReader(sigdata[1:]), req)
 }
 
 func (req *ping) handle(t *udp, from *net.UDPAddr, fromID NodeID, mac []byte) error {

--- a/p2p/discv5/udp.go
+++ b/p2p/discv5/udp.go
@@ -443,7 +443,5 @@ func decodePacket(buffer []byte, pkt *ingressPacket) error {
 	default:
 		return fmt.Errorf("unknown packet type: %d", sigdata[0])
 	}
-	s := rlp.NewStream(bytes.NewReader(sigdata[1:]), 0)
-	err = s.Decode(pkt.data)
-	return err
+	return rlp.Decode(bytes.NewReader(sigdata[1:]), pkt.data)
 }

--- a/p2p/enr/enr.go
+++ b/p2p/enr/enr.go
@@ -157,6 +157,7 @@ func (r *Record) DecodeRLP(s *rlp.Stream) error {
 	// Decode the RLP container.
 	dec := Record{raw: raw}
 	s = rlp.NewStream(bytes.NewReader(raw), 0)
+	rlp.Discard(s)
 	if _, err := s.List(); err != nil {
 		return err
 	}

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -52,6 +52,7 @@ type Msg struct {
 // For the decoding rules, please see package rlp.
 func (msg Msg) Decode(val interface{}) error {
 	s := rlp.NewStream(msg.Payload, uint64(msg.Size))
+	defer rlp.Discard(s)
 	if err := s.Decode(val); err != nil {
 		return newPeerError(errInvalidMsg, "(code %x) (size %d) %v", msg.Code, msg.Size, err)
 	}

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -506,8 +506,7 @@ func readHandshakeMsg(msg plainDecoder, plainSize int, prv *ecdsa.PrivateKey, r 
 	}
 	// Can't use rlp.DecodeBytes here because it rejects
 	// trailing data (forward-compatibility).
-	s := rlp.NewStream(bytes.NewReader(dec), 0)
-	return buf, s.Decode(msg)
+	return buf, rlp.Decode(bytes.NewReader(dec), msg)
 }
 
 // importPublicKey unmarshals 512 bit public keys.

--- a/rlp/decode_test.go
+++ b/rlp/decode_test.go
@@ -817,3 +817,29 @@ func unhex(str string) []byte {
 	}
 	return b
 }
+
+func BenchmarkStreamPool(b *testing.B) {
+	enc := encodeTestSlice(5)
+	b.Run("unpooled", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			var s []uint
+			r := bytes.NewReader(enc)
+			st := new(Stream)
+			st.Reset(r, 0)
+			if err := st.Decode(&s); err != nil {
+				b.Fatalf("Decode error: %v", err)
+			}
+		}
+	})
+	b.Run("pooled", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			var s []uint
+			r := bytes.NewReader(enc)
+			if err := Decode(r, &s); err != nil {
+				b.Fatalf("Decode error: %v", err)
+			}
+		}
+	})
+}

--- a/swarm/storage/dbstore.go
+++ b/swarm/storage/dbstore.go
@@ -158,8 +158,7 @@ func encodeData(chunk *Chunk) []byte {
 }
 
 func decodeIndex(data []byte, index *dpaDBIndex) {
-	dec := rlp.NewStream(bytes.NewReader(data), 0)
-	dec.Decode(index)
+	_ = rlp.Decode(bytes.NewReader(data), index)
 }
 
 func decodeData(data []byte, chunk *Chunk) {

--- a/whisper/whisperv6/peer.go
+++ b/whisper/whisperv6/peer.go
@@ -93,6 +93,7 @@ func (peer *Peer) handshake() error {
 		return fmt.Errorf("peer [%x] sent packet %x before status packet", peer.ID(), packet.Code)
 	}
 	s := rlp.NewStream(packet.Payload, uint64(packet.Size))
+	defer rlp.Discard(s)
 	_, err = s.List()
 	if err != nil {
 		return fmt.Errorf("peer [%x] sent bad status message: %v", peer.ID(), err)

--- a/whisper/whisperv6/whisper.go
+++ b/whisper/whisperv6/whisper.go
@@ -689,6 +689,7 @@ func (whisper *Whisper) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
 		case powRequirementCode:
 			s := rlp.NewStream(packet.Payload, uint64(packet.Size))
 			i, err := s.Uint()
+			rlp.Discard(s)
 			if err != nil {
 				log.Warn("failed to decode powRequirementCode message, peer will be disconnected", "peer", p.peer.ID(), "err", err)
 				return errors.New("invalid powRequirementCode message")


### PR DESCRIPTION
This PR introduces a `sync.Pool` of `rlp.Stream`s to reduce garbage from decoding. For example, `BenchmarkStreamPool`:
```
BenchmarkStreamPool/unpooled-4         	 1000000	      1199 ns/op	     376 B/op	       9 allocs/op
BenchmarkStreamPool/pooled-4           	 1000000	      1131 ns/op	     224 B/op	       6 allocs/op
```