### PR TITLE
log: short circuit trace logging on the hot path

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -720,7 +720,9 @@ func (pm *ProtocolManager) BroadcastTx(hash common.Hash, tx *types.Transaction) 
 	for _, peer := range peers {
 		peer.SendTransactions(types.Transactions{tx})
 	}
-	log.Trace("Broadcast transaction", "hash", hash, "recipients", len(peers))
+	if log.Tracing() {
+		log.Trace("Broadcast transaction", "hash", hash, "recipients", len(peers))
+	}
 }
 
 // Mined broadcast loop

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1167,9 +1167,13 @@ func submitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 			return common.Hash{}, err
 		}
 		addr := crypto.CreateAddress(from, tx.Nonce())
-		log.Trace("Submitted contract creation", "fullhash", tx.Hash().Hex(), "contract", addr.Hex())
+		if log.Tracing() {
+			log.Trace("Submitted contract creation", "fullhash", tx.Hash().Hex(), "contract", addr.Hex())
+		}
 	} else {
-		log.Trace("Submitted transaction", "fullhash", tx.Hash().Hex(), "recipient", tx.To())
+		if log.Tracing() {
+			log.Trace("Submitted transaction", "fullhash", tx.Hash().Hex(), "recipient", tx.To())
+		}
 	}
 	return tx.Hash(), nil
 }

--- a/log/handler.go
+++ b/log/handler.go
@@ -17,18 +17,30 @@ import (
 // them to achieve the logging structure that suits your applications.
 type Handler interface {
 	Log(r *Record) error
+	// IsLogging returns true if global logging for level is enabled.
+	IsLogging(Lvl) bool
 }
 
 // FuncHandler returns a Handler that logs records with the given
-// function.
-func FuncHandler(fn func(r *Record) error) Handler {
-	return funcHandler(fn)
+// functions.
+func FuncHandler(log func(r *Record) error, isLogging func(Lvl) bool) Handler {
+	return &funcHandler{
+		log:       log,
+		isLogging: isLogging,
+	}
 }
 
-type funcHandler func(r *Record) error
+type funcHandler struct {
+	log       func(r *Record) error
+	isLogging func(Lvl) bool
+}
 
 func (h funcHandler) Log(r *Record) error {
-	return h(r)
+	return h.log(r)
+}
+
+func (h funcHandler) IsLogging(level Lvl) bool {
+	return h.isLogging(level)
 }
 
 // StreamHandler writes log records to an io.Writer
@@ -42,7 +54,7 @@ func StreamHandler(wr io.Writer, fmtr Format) Handler {
 	h := FuncHandler(func(r *Record) error {
 		_, err := wr.Write(fmtr.Format(r))
 		return err
-	})
+	}, func(Lvl) bool { return true })
 	return LazyHandler(SyncHandler(h))
 }
 
@@ -52,10 +64,11 @@ func StreamHandler(wr io.Writer, fmtr Format) Handler {
 func SyncHandler(h Handler) Handler {
 	var mu sync.Mutex
 	return FuncHandler(func(r *Record) error {
-		defer mu.Unlock()
 		mu.Lock()
-		return h.Log(r)
-	})
+		err := h.Log(r)
+		mu.Unlock()
+		return err
+	}, h.IsLogging)
 }
 
 // FileHandler returns a handler which writes log records to the give file
@@ -93,44 +106,6 @@ func (h *closingHandler) Close() error {
 	return h.WriteCloser.Close()
 }
 
-// CallerFileHandler returns a Handler that adds the line number and file of
-// the calling function to the context with key "caller".
-func CallerFileHandler(h Handler) Handler {
-	return FuncHandler(func(r *Record) error {
-		r.Ctx = append(r.Ctx, "caller", fmt.Sprint(r.Call))
-		return h.Log(r)
-	})
-}
-
-// CallerFuncHandler returns a Handler that adds the calling function name to
-// the context with key "fn".
-func CallerFuncHandler(h Handler) Handler {
-	return FuncHandler(func(r *Record) error {
-		r.Ctx = append(r.Ctx, "fn", formatCall("%+n", r.Call))
-		return h.Log(r)
-	})
-}
-
-// This function is here to please go vet on Go < 1.8.
-func formatCall(format string, c stack.Call) string {
-	return fmt.Sprintf(format, c)
-}
-
-// CallerStackHandler returns a Handler that adds a stack trace to the context
-// with key "stack". The stack trace is formated as a space separated list of
-// call sites inside matching []'s. The most recent call site is listed first.
-// Each call site is formatted according to format. See the documentation of
-// package github.com/go-stack/stack for the list of supported formats.
-func CallerStackHandler(format string, h Handler) Handler {
-	return FuncHandler(func(r *Record) error {
-		s := stack.Trace().TrimBelow(r.Call).TrimRuntime()
-		if len(s) > 0 {
-			r.Ctx = append(r.Ctx, "stack", fmt.Sprintf(format, s))
-		}
-		return h.Log(r)
-	})
-}
-
 // FilterHandler returns a Handler that only writes records to the
 // wrapped Handler if the given function evaluates true. For example,
 // to only log records where the 'err' key is not nil:
@@ -150,34 +125,7 @@ func FilterHandler(fn func(r *Record) bool, h Handler) Handler {
 			return h.Log(r)
 		}
 		return nil
-	})
-}
-
-// MatchFilterHandler returns a Handler that only writes records
-// to the wrapped Handler if the given key in the logged
-// context matches the value. For example, to only log records
-// from your ui package:
-//
-//    log.MatchFilterHandler("pkg", "app/ui", log.StdoutHandler)
-//
-func MatchFilterHandler(key string, value interface{}, h Handler) Handler {
-	return FilterHandler(func(r *Record) (pass bool) {
-		switch key {
-		case r.KeyNames.Lvl:
-			return r.Lvl == value
-		case r.KeyNames.Time:
-			return r.Time == value
-		case r.KeyNames.Msg:
-			return r.Msg == value
-		}
-
-		for i := 0; i < len(r.Ctx); i += 2 {
-			if r.Ctx[i] == key {
-				return r.Ctx[i+1] == value
-			}
-		}
-		return false
-	}, h)
+	}, h.IsLogging)
 }
 
 // LvlFilterHandler returns a Handler that only writes
@@ -191,81 +139,6 @@ func LvlFilterHandler(maxLvl Lvl, h Handler) Handler {
 	return FilterHandler(func(r *Record) (pass bool) {
 		return r.Lvl <= maxLvl
 	}, h)
-}
-
-// A MultiHandler dispatches any write to each of its handlers.
-// This is useful for writing different types of log information
-// to different locations. For example, to log to a file and
-// standard error:
-//
-//     log.MultiHandler(
-//         log.Must.FileHandler("/var/log/app.log", log.LogfmtFormat()),
-//         log.StderrHandler)
-//
-func MultiHandler(hs ...Handler) Handler {
-	return FuncHandler(func(r *Record) error {
-		for _, h := range hs {
-			// what to do about failures?
-			h.Log(r)
-		}
-		return nil
-	})
-}
-
-// A FailoverHandler writes all log records to the first handler
-// specified, but will failover and write to the second handler if
-// the first handler has failed, and so on for all handlers specified.
-// For example you might want to log to a network socket, but failover
-// to writing to a file if the network fails, and then to
-// standard out if the file write fails:
-//
-//     log.FailoverHandler(
-//         log.Must.NetHandler("tcp", ":9090", log.JsonFormat()),
-//         log.Must.FileHandler("/var/log/app.log", log.LogfmtFormat()),
-//         log.StdoutHandler)
-//
-// All writes that do not go to the first handler will add context with keys of
-// the form "failover_err_{idx}" which explain the error encountered while
-// trying to write to the handlers before them in the list.
-func FailoverHandler(hs ...Handler) Handler {
-	return FuncHandler(func(r *Record) error {
-		var err error
-		for i, h := range hs {
-			err = h.Log(r)
-			if err == nil {
-				return nil
-			} else {
-				r.Ctx = append(r.Ctx, fmt.Sprintf("failover_err_%d", i), err)
-			}
-		}
-
-		return err
-	})
-}
-
-// ChannelHandler writes all records to the given channel.
-// It blocks if the channel is full. Useful for async processing
-// of log messages, it's used by BufferedHandler.
-func ChannelHandler(recs chan<- *Record) Handler {
-	return FuncHandler(func(r *Record) error {
-		recs <- r
-		return nil
-	})
-}
-
-// BufferedHandler writes all records to a buffered
-// channel of the given size which flushes into the wrapped
-// handler whenever it is available for writing. Since these
-// writes happen asynchronously, all writes to a BufferedHandler
-// never return an error and any errors from the wrapped handler are ignored.
-func BufferedHandler(bufSize int, h Handler) Handler {
-	recs := make(chan *Record, bufSize)
-	go func() {
-		for m := range recs {
-			_ = h.Log(m)
-		}
-	}()
-	return ChannelHandler(recs)
 }
 
 // LazyHandler writes all values to the wrapped handler after evaluating
@@ -298,7 +171,7 @@ func LazyHandler(h Handler) Handler {
 		}
 
 		return h.Log(r)
-	})
+	}, h.IsLogging)
 }
 
 func evaluateLazy(lz Lazy) (interface{}, error) {
@@ -335,7 +208,7 @@ func evaluateLazy(lz Lazy) (interface{}, error) {
 func DiscardHandler() Handler {
 	return FuncHandler(func(r *Record) error {
 		return nil
-	})
+	}, func(Lvl) bool { return false })
 }
 
 // The Must object provides the following Handler creation functions

--- a/log/handler_glog.go
+++ b/log/handler_glog.go
@@ -70,6 +70,10 @@ func (h *GlogHandler) Verbosity(level Lvl) {
 	atomic.StoreUint32(&h.level, uint32(level))
 }
 
+func (h *GlogHandler) IsLogging(level Lvl) bool {
+	return atomic.LoadUint32(&h.level) >= uint32(level)
+}
+
 // Vmodule sets the glog verbosity pattern.
 //
 // The syntax of the argument is a comma-separated list of pattern=N, where the

--- a/log/handler_go13.go
+++ b/log/handler_go13.go
@@ -17,6 +17,10 @@ func (h *swapHandler) Log(r *Record) error {
 	return h.Get().Log(r)
 }
 
+func (h *swapHandler) IsLogging(level Lvl) bool {
+	return h.Get().IsLogging(level)
+}
+
 func (h *swapHandler) Get() Handler {
 	return *(*Handler)(atomic.LoadPointer(&h.handler))
 }

--- a/log/handler_go14.go
+++ b/log/handler_go14.go
@@ -14,6 +14,10 @@ func (h *swapHandler) Log(r *Record) error {
 	return (*h.handler.Load().(*Handler)).Log(r)
 }
 
+func (h *swapHandler) IsLogging(level Lvl) bool {
+	return h.Get().IsLogging(level)
+}
+
 func (h *swapHandler) Swap(newHandler Handler) {
 	h.handler.Store(&newHandler)
 }

--- a/log/root.go
+++ b/log/root.go
@@ -59,3 +59,13 @@ func Crit(msg string, ctx ...interface{}) {
 	root.write(msg, LvlCrit, ctx)
 	os.Exit(1)
 }
+
+// IsLogging returns true if global logging for level is enabled. Check this
+// to avoid costly message formatting which would just be discarded anyways.
+func IsLogging(level Lvl) bool {
+	return root.h.IsLogging(level)
+}
+
+func Tracing() bool {
+	return IsLogging(LvlTrace)
+}

--- a/log/syslog.go
+++ b/log/syslog.go
@@ -44,7 +44,7 @@ func sharedSyslog(fmtr Format, sysWr *syslog.Writer, err error) (Handler, error)
 
 		s := strings.TrimSpace(string(fmtr.Format(r)))
 		return syslogFn(s)
-	})
+	}, func(Lvl) bool { return false })
 	return LazyHandler(&closingHandler{sysWr, h}), nil
 }
 

--- a/p2p/discover/udp.go
+++ b/p2p/discover/udp.go
@@ -300,12 +300,15 @@ func (t *udp) findnode(toid NodeID, toaddr *net.UDPAddr, target NodeID) ([]*Node
 	nodes := make([]*Node, 0, bucketSize)
 	nreceived := 0
 	errc := t.pending(toid, neighborsPacket, func(r interface{}) bool {
+		tracing := log.Tracing()
 		reply := r.(*neighbors)
 		for _, rn := range reply.Nodes {
 			nreceived++
 			n, err := t.nodeFromRPC(toaddr, rn)
 			if err != nil {
-				log.Trace("Invalid neighbor node received", "ip", rn.IP, "addr", toaddr, "err", err)
+				if tracing {
+					log.Trace("Invalid neighbor node received", "ip", rn.IP, "addr", toaddr, "err", err)
+				}
 				continue
 			}
 			nodes = append(nodes, n)
@@ -480,7 +483,9 @@ func (t *udp) send(toaddr *net.UDPAddr, ptype byte, req packet) ([]byte, error) 
 
 func (t *udp) write(toaddr *net.UDPAddr, what string, packet []byte) error {
 	_, err := t.conn.WriteToUDP(packet, toaddr)
-	log.Trace(">> "+what, "addr", toaddr, "err", err)
+	if log.Tracing() {
+		log.Trace(">> "+what, "addr", toaddr, "err", err)
+	}
 	return err
 }
 
@@ -544,7 +549,9 @@ func (t *udp) handlePacket(from *net.UDPAddr, buf []byte) error {
 		return err
 	}
 	err = packet.handle(t, from, fromID, hash)
-	log.Trace("<< "+packet.name(), "addr", from, "err", err)
+	if log.Tracing() {
+		log.Trace("<< "+packet.name(), "addr", from, "err", err)
+	}
 	return err
 }
 

--- a/p2p/discv5/net.go
+++ b/p2p/discv5/net.go
@@ -428,10 +428,12 @@ loop:
 			if err := net.handle(n, pkt.ev, &pkt); err != nil {
 				status = err.Error()
 			}
-			log.Trace("", "msg", log.Lazy{Fn: func() string {
-				return fmt.Sprintf("<<< (%d) %v from %x@%v: %v -> %v (%v)",
-					net.tab.count, pkt.ev, pkt.remoteID[:8], pkt.remoteAddr, prestate, n.state, status)
-			}})
+			if log.Tracing() {
+				log.Trace("", "msg", log.Lazy{Fn: func() string {
+					return fmt.Sprintf("<<< (%d) %v from %x@%v: %v -> %v (%v)",
+						net.tab.count, pkt.ev, pkt.remoteID[:8], pkt.remoteAddr, prestate, n.state, status)
+				}})
+			}
 			// TODO: persist state if n.state goes >= known, delete if it goes <= known
 
 		// State transition timeouts.

--- a/p2p/discv5/udp.go
+++ b/p2p/discv5/udp.go
@@ -341,9 +341,14 @@ func (t *udp) sendPacket(toid NodeID, toaddr *net.UDPAddr, ptype byte, req inter
 		//fmt.Println(err)
 		return hash, err
 	}
-	log.Trace(fmt.Sprintf(">>> %v to %x@%v", nodeEvent(ptype), toid[:8], toaddr))
+	tracing := log.Tracing()
+	if tracing {
+		log.Trace(fmt.Sprintf(">>> %v to %x@%v", nodeEvent(ptype), toid[:8], toaddr))
+	}
 	if _, err = t.conn.WriteToUDP(packet, toaddr); err != nil {
-		log.Trace(fmt.Sprint("UDP send failed:", err))
+		if tracing {
+			log.Trace(fmt.Sprint("UDP send failed:", err))
+		}
 	}
 	//fmt.Println(err)
 	return hash, err

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -418,9 +418,11 @@ func (c *Client) newMessage(method string, paramsIn ...interface{}) (*jsonrpcMes
 func (c *Client) send(ctx context.Context, op *requestOp, msg interface{}) error {
 	select {
 	case c.requestOp <- op:
-		log.Trace("", "msg", log.Lazy{Fn: func() string {
-			return fmt.Sprint("sending ", msg)
-		}})
+		if log.Tracing() {
+			log.Trace("", "msg", log.Lazy{Fn: func() string {
+				return fmt.Sprint("sending ", msg)
+			}})
+		}
 		err := c.write(ctx, msg)
 		c.sendDone <- err
 		return err
@@ -506,14 +508,18 @@ func (c *Client) dispatch(conn net.Conn) {
 			for _, msg := range batch {
 				switch {
 				case msg.isNotification():
-					log.Trace("", "msg", log.Lazy{Fn: func() string {
-						return fmt.Sprint("<-readResp: notification ", msg)
-					}})
+					if log.Tracing() {
+						log.Trace("", "msg", log.Lazy{Fn: func() string {
+							return fmt.Sprint("<-readResp: notification ", msg)
+						}})
+					}
 					c.handleNotification(msg)
 				case msg.isResponse():
-					log.Trace("", "msg", log.Lazy{Fn: func() string {
-						return fmt.Sprint("<-readResp: response ", msg)
-					}})
+					if log.Tracing() {
+						log.Trace("", "msg", log.Lazy{Fn: func() string {
+							return fmt.Sprint("<-readResp: response ", msg)
+						}})
+					}
 					c.handleResponse(msg)
 				default:
 					log.Debug("", "msg", log.Lazy{Fn: func() string {


### PR DESCRIPTION
This PR extends the `log` API with support for checking the log level directly. This enables short circuiting before calling `log.Trace`, avoiding wasting CPU and memory formatting a message and doing internal log handler synchronization. The biggest affect should be in the per-tx sections.

The pre-existing `log.Lazy` already addresses the problem somewhat, but requires passing a closure and still goes through the internal synchronization.