### PR TITLE
consensus: Engine.Finalize() - make block assembly optional to avoid extra discarded work

### DIFF
--- a/consensus/clique/gochain.go
+++ b/consensus/clique/gochain.go
@@ -11,13 +11,16 @@ import (
 )
 
 // Finalize implements consensus.Engine, ensuring no uncles are set, but this does give rewards.
-func (c *Clique) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
+func (c *Clique) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt, block bool) *types.Block {
 	//accumulateRewards(chain.Config(), state, header, uncles)
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 	header.UncleHash = types.CalcUncleHash(nil)
 
-	// Assemble and return the final block for sealing
-	return types.NewBlock(header, txs, nil, receipts), nil
+	if block {
+		// Assemble and return the final block for sealing
+		return types.NewBlock(header, txs, nil, receipts)
+	}
+	return nil
 }
 
 // Some weird constants to avoid constant memory allocs for them.

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -79,11 +79,11 @@ type Engine interface {
 	Prepare(chain ChainReader, header *types.Header) error
 
 	// Finalize runs any post-transaction state modifications (e.g. block rewards)
-	// and assembles the final block.
+	// and assembles the final block (if block is true).
 	// Note: The block header and state database might be updated to reflect any
 	// consensus rules that happen at finalization (e.g. block rewards).
 	Finalize(chain ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction,
-		uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error)
+		uncles []*types.Header, receipts []*types.Receipt, block bool) *types.Block
 
 	// Seal generates a new block for the given input block with the local miner's
 	// seal place on top.

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -518,13 +518,16 @@ func (ethash *Ethash) Prepare(chain consensus.ChainReader, header *types.Header)
 
 // Finalize implements consensus.Engine, accumulating the block and uncle rewards,
 // setting the final state and assembling the block.
-func (ethash *Ethash) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
+func (ethash *Ethash) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt, block bool) *types.Block {
 	// Accumulate any block and uncle rewards and commit the final state root
 	accumulateRewards(chain.Config(), state, header, uncles)
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 
-	// Header seems complete, assemble into a block and return
-	return types.NewBlock(header, txs, uncles, receipts), nil
+	if block {
+		// Header seems complete, assemble into a block and return
+		return types.NewBlock(header, txs, uncles, receipts)
+	}
+	return nil
 }
 
 // Some weird constants to avoid constant memory allocs for them.

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -190,7 +190,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 		}
 
 		if b.engine != nil {
-			block, _ := b.engine.Finalize(b.chainReader, b.header, statedb, b.txs, b.uncles, b.receipts)
+			block := b.engine.Finalize(b.chainReader, b.header, statedb, b.txs, b.uncles, b.receipts, true)
 			// Write state changes to db
 			root, err := statedb.Commit(config.IsEIP158(b.header.Number))
 			if err != nil {

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -78,7 +78,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		allLogs = append(allLogs, receipt.Logs...)
 	}
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
-	p.engine.Finalize(p.bc, header, statedb, block.Transactions(), block.Uncles(), receipts)
+	_ = p.engine.Finalize(p.bc, header, statedb, block.Transactions(), block.Uncles(), receipts, false)
 
 	return receipts, allLogs, *usedGas, nil
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -479,10 +479,7 @@ func (self *worker) commitNewWork() {
 		delete(self.possibleUncles, hash)
 	}
 	// Create the new block to seal with the consensus engine
-	if work.Block, err = self.engine.Finalize(self.chain, header, work.state, work.txs, uncles, work.receipts); err != nil {
-		log.Error("Failed to finalize block for sealing", "err", err)
-		return
-	}
+	work.Block = self.engine.Finalize(self.chain, header, work.state, work.txs, uncles, work.receipts, true)
 	// We only care about logging if we're actually mining.
 	if atomic.LoadInt32(&self.mining) == 1 {
 		log.Info("Commit new mining work", "number", work.Block.Number(), "txs", work.tcount, "uncles", len(uncles), "elapsed", common.PrettyDuration(time.Since(tstart)))


### PR DESCRIPTION
`(*StateProcessor).Process` discards the `Block` returned from `Engine.Finalize`.  Assembling the block involves costly copying and hashing. This change adds a boolean parameter to bypass assembling the block.