### PR TITLE
core: (*StateProcessor).Process - precompute types.Sender() in parallel

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -86,7 +86,8 @@ func (b *BlockGen) AddTx(tx *types.Transaction) {
 		b.SetCoinbase(common.Address{})
 	}
 	b.statedb.Prepare(tx.Hash(), common.Hash{}, len(b.txs))
-	receipt, _, err := ApplyTransaction(b.config, nil, &b.header.Coinbase, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, vm.Config{}, vm.NewIntPool())
+	signer := types.MakeSigner(b.config, b.header.Number)
+	receipt, _, err := ApplyTransaction(b.config, nil, &b.header.Coinbase, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, vm.Config{}, vm.NewIntPool(), signer)
 	if err != nil {
 		panic(err)
 	}

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -1,0 +1,55 @@
+package core
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/gochain-io/gochain/common"
+	"github.com/gochain-io/gochain/core/state"
+	"github.com/gochain-io/gochain/core/types"
+	"github.com/gochain-io/gochain/core/vm"
+	"github.com/gochain-io/gochain/crypto"
+	"github.com/gochain-io/gochain/params"
+)
+
+func BenchmarkStateProcessor_Process(b *testing.B) {
+	key, _ := crypto.GenerateKey()
+	address := crypto.PubkeyToAddress(key.PublicKey)
+	funds := big.NewInt(1000000000)
+
+	genesis := &Genesis{
+		Config:     params.TestChainConfig,
+		Difficulty: big.NewInt(1),
+		Alloc:      GenesisAlloc{address: {Balance: funds}},
+	}
+	signer := types.NewEIP155Signer(genesis.Config.ChainId)
+
+	bc := newTestBlockChainWithGenesis(true, true, genesis)
+	defer bc.Stop()
+	cfg := vm.Config{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		txs := make([]*types.Transaction, 1000)
+		for i := 0; i < 1000; i++ {
+			tx := types.NewTransaction(uint64(i), common.Address{}, big.NewInt(100), 100000, big.NewInt(1), nil)
+			tx, _ = types.SignTx(tx, signer, key)
+			txs[i] = tx
+		}
+
+		block := types.NewBlock(&types.Header{
+			GasLimit: bc.GasLimit(),
+		}, txs, nil, nil)
+		statedb, err := state.New(bc.CurrentBlock().Root(), bc.stateCache)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+
+		_, _, _, err = bc.Processor().Process(block, statedb, cfg)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -604,7 +604,8 @@ func (env *Work) commitTransactions(mux *event.TypeMux, txs *types.TransactionsB
 
 func (env *Work) commitTransaction(tx *types.Transaction, bc *core.BlockChain, coinbase common.Address, gp *core.GasPool, intPool *vm.IntPool) (error, []*types.Log) {
 	snap := env.state.Snapshot()
-	receipt, _, err := core.ApplyTransaction(env.config, bc, &coinbase, gp, env.state, env.header, tx, &env.header.GasUsed, vm.Config{}, intPool)
+	signer := types.MakeSigner(env.config, env.header.Number)
+	receipt, _, err := core.ApplyTransaction(env.config, bc, &coinbase, gp, env.state, env.header, tx, &env.header.GasUsed, vm.Config{}, intPool, signer)
 	if err != nil {
 		env.state.RevertToSnapshot(snap)
 		return err, nil


### PR DESCRIPTION
This changes introduces parallel processing of tx senders via `types.Sender()` from `(*StateProcessor).Process`. The number of parallel goroutines is set to `GOMAXPROCS-1`.

`TestStateProcessor` was picked out of #69 and adapted into a `Benchmark`.
Here are some `benchcmp` results from my machine with `GOMAXPROCS=1` (old: no parallel goroutines) and `4` (new: 3 parallel goroutines):
```
benchmark                   old ns/op     new ns/op     delta
BenchmarkStateProcessor     228557797     122436604     -46.43%

benchmark                   old allocs     new allocs     delta
BenchmarkStateProcessor     157164         161665         +2.86%

benchmark                   old bytes     new bytes     delta
BenchmarkStateProcessor     31694936      32096709      +1.27%
```