### PR TITLE
core/state: Account.CodeHash as common.Hash instead of []byte

### DIFF
--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -58,7 +58,7 @@ func (self *StateDB) RawDump() Dump {
 			Balance:  data.Balance.String(),
 			Nonce:    data.Nonce,
 			Root:     common.Bytes2Hex(data.Root[:]),
-			CodeHash: common.Bytes2Hex(data.CodeHash),
+			CodeHash: common.Bytes2Hex(data.CodeHash[:]),
 			Code:     common.Bytes2Hex(obj.Code(self.db)),
 			Storage:  make(map[string]string),
 		}

--- a/core/state/iterator.go
+++ b/core/state/iterator.go
@@ -116,10 +116,10 @@ func (it *NodeIterator) step() error {
 	if !it.dataIt.Next(true) {
 		it.dataIt = nil
 	}
-	if !bytes.Equal(account.CodeHash, emptyCodeHash) {
-		it.codeHash = common.BytesToHash(account.CodeHash)
+	if account.CodeHash != emptyCodeHash {
+		it.codeHash = account.CodeHash
 		addrHash := common.BytesToHash(it.stateIt.LeafKey())
-		it.code, err = it.state.db.ContractCode(addrHash, common.BytesToHash(account.CodeHash))
+		it.code, err = it.state.db.ContractCode(addrHash, account.CodeHash)
 		if err != nil {
 			return fmt.Errorf("code %x: %v", account.CodeHash, err)
 		}

--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -56,8 +56,9 @@ type (
 		key, prevalue common.Hash
 	}
 	codeChange struct {
-		account            *common.Address
-		prevcode, prevhash []byte
+		account  *common.Address
+		prevcode []byte
+		prevhash common.Hash
 	}
 
 	// Changes to other state values.
@@ -114,7 +115,7 @@ func (ch nonceChange) undo(s *StateDB) {
 }
 
 func (ch codeChange) undo(s *StateDB) {
-	s.getStateObject(*ch.account).setCode(common.BytesToHash(ch.prevhash), ch.prevcode)
+	s.getStateObject(*ch.account).setCode(ch.prevhash, ch.prevcode)
 }
 
 func (ch storageChange) undo(s *StateDB) {

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -202,8 +202,8 @@ func compareStateObjects(so0, so1 *stateObject, t *testing.T) {
 	if so0.data.Root != so1.data.Root {
 		t.Errorf("Root mismatch: have %x, want %x", so0.data.Root[:], so1.data.Root[:])
 	}
-	if !bytes.Equal(so0.CodeHash(), so1.CodeHash()) {
-		t.Fatalf("CodeHash mismatch: have %v, want %v", so0.CodeHash(), so1.CodeHash())
+	if so0.data.CodeHash != so1.data.CodeHash {
+		t.Fatalf("CodeHash mismatch: have %v, want %v", so0.data.CodeHash, so1.data.CodeHash)
 	}
 	if !bytes.Equal(so0.code, so1.code) {
 		t.Fatalf("Code mismatch: have %v, want %v", so0.code, so1.code)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -220,7 +220,7 @@ func (self *StateDB) GetCodeSize(addr common.Address) int {
 	if stateObject.code != nil {
 		return len(stateObject.code)
 	}
-	size, err := self.db.ContractCodeSize(stateObject.addrHash, common.BytesToHash(stateObject.CodeHash()))
+	size, err := self.db.ContractCodeSize(stateObject.addrHash, stateObject.data.CodeHash)
 	if err != nil {
 		self.setError(err)
 	}
@@ -232,7 +232,7 @@ func (self *StateDB) GetCodeHash(addr common.Address) common.Hash {
 	if stateObject == nil {
 		return common.Hash{}
 	}
-	return common.BytesToHash(stateObject.CodeHash())
+	return stateObject.data.CodeHash
 }
 
 func (self *StateDB) GetState(a common.Address, b common.Hash) common.Hash {
@@ -596,7 +596,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (root common.Hash, err error) 
 		case isDirty:
 			// Write any contract code associated with the state object
 			if stateObject.code != nil && stateObject.dirtyCode {
-				s.db.TrieDB().Insert(common.BytesToHash(stateObject.CodeHash()), stateObject.code)
+				s.db.TrieDB().Insert(stateObject.data.CodeHash, stateObject.code)
 				stateObject.dirtyCode = false
 			}
 			// Write any storage changes in the state object to its storage trie.
@@ -617,7 +617,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (root common.Hash, err error) 
 		if account.Root != emptyState {
 			s.db.TrieDB().Reference(account.Root, parent)
 		}
-		code := common.BytesToHash(account.CodeHash)
+		code := account.CodeHash
 		if code != emptyCode {
 			s.db.TrieDB().Reference(code, parent)
 		}

--- a/core/state/sync.go
+++ b/core/state/sync.go
@@ -33,7 +33,7 @@ func NewStateSync(root common.Hash, database trie.DatabaseReader) *trie.TrieSync
 			return err
 		}
 		syncer.AddSubTrie(obj.Root, 64, parent, nil)
-		syncer.AddRawEntry(common.BytesToHash(obj.CodeHash), 64, parent)
+		syncer.AddRawEntry(obj.CodeHash, 64, parent)
 		return nil
 	}
 	syncer = trie.NewTrieSync(root, database, callback)

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -86,12 +86,12 @@ func TestStateProcessor(t *testing.T) {
 	// 		t.Fatal(err)
 	// 	}
 	perfTimer := perfutils.GetTimer(ctx)
-	txs := []*types.Transaction{}
+	txs := make([]*types.Transaction, numTxs)
 	for i := 0; i < numTxs; i++ {
 		tx := types.NewTransaction(uint64(i), common.Address{}, big.NewInt(100), 100000, big.NewInt(1), nil)
 		tx, _ = types.SignTx(tx, signer, key)
 		// txs = append(txs, types.NewTransaction(uint64(i), common.Address{}, big.NewInt(1), uint64(21000), big.NewInt(21000), nil))
-		txs = append(txs, tx)
+		txs[i] = tx
 	}
 	block := types.NewBlock(&types.Header{
 		GasLimit: bc.GasLimit(),

--- a/core/types/bloom9.go
+++ b/core/types/bloom9.go
@@ -117,10 +117,11 @@ func bloom9(b []byte) *big.Int {
 
 	r := new(big.Int)
 
+	var t big.Int
 	for i := 0; i < 6; i += 2 {
-		t := big.NewInt(1)
+		t.SetUint64(1)
 		b := (uint(h[i+1]) + (uint(h[i]) << 8)) & 2047
-		r.Or(r, t.Lsh(t, b))
+		r.Or(r, t.Lsh(&t, b))
 	}
 
 	return r
@@ -130,7 +131,7 @@ var Bloom9 = bloom9
 
 func BloomLookup(bin Bloom, topic bytesBacked) bool {
 	bloom := bin.Big()
-	cmp := bloom9(topic.Bytes()[:])
+	cmp := bloom9(topic.Bytes())
 
 	return bloom.And(bloom, cmp).Cmp(cmp) == 0
 }

--- a/les/handler.go
+++ b/les/handler.go
@@ -588,7 +588,7 @@ func (pm *ProtocolManager) handleMsg(ctx context.Context, p *peer) error {
 				if err != nil {
 					continue
 				}
-				code, _ := statedb.Database().TrieDB().Node(common.BytesToHash(account.CodeHash))
+				code, _ := statedb.Database().TrieDB().Node(account.CodeHash)
 
 				data = append(data, code)
 				if bytes += len(code); bytes >= softResponseLimit {


### PR DESCRIPTION
`Account.CodeHash` was being converted back and forth from `common.Hash` to `[]byte`. Just use `common.Hash` instead.

Alloc less in `bloom9` by reusing a `big.Int`.