### PR TITLE
core: (*StateProcessor).Process compute tx hash in parallel along with sender

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -82,6 +82,7 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 		go func() {
 			for i := atomic.AddInt32(&wi, 1); i < l32; i = atomic.AddInt32(&wi, 1) {
 				types.Sender(ctx, signer, txs[i])
+				txs[i].Hash()
 			}
 		}()
 	}


### PR DESCRIPTION
Precompute the hash in parallel alongside the sender.  This made up most of the time measured by the perf timer for `statedb.Prepare`. Roughly: `72.010179ms` down to `22.662882ms`.