### PR TITLE
core: (*StateProcessor).Process - increase parallel workers

### DIFF
--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -72,7 +72,6 @@ func SignTx(tx *Transaction, s Signer, prv *ecdsa.PrivateKey) (*Transaction, err
 // signing method. The cache is invalidated if the cached signer does
 // not match the signer used in the current call.
 func Sender(ctx context.Context, signer Signer, tx *Transaction) (common.Address, error) {
-	perfTimer := perfutils.GetTimer(ctx)
 	if sc := tx.from.Load(); sc != nil {
 		sigCache := sc.(sigCache)
 		// If the signer used to derive from in a previous
@@ -82,7 +81,7 @@ func Sender(ctx context.Context, signer Signer, tx *Transaction) (common.Address
 			return sigCache.from, nil
 		}
 	}
-
+	perfTimer := perfutils.GetTimer(ctx)
 	ps := perfTimer.Start(perfutils.SignerSender)
 	addr, err := signer.Sender(tx)
 	if err != nil {


### PR DESCRIPTION
A typical run of `TestStateProcessor` for 10000 txs might show `signer.Sender` being called 12438 times. This indicates 2438 extra calls which recompute an already cached value, simply due to unlucky scheduling between the main routine and the parallel workers (an atomic load in between another routine's atomic load and store, so that they both recompute and store). Increasing the number of parallel workers allows them to stay ahead of the main routine, and reduces the number of redundant calls. For example: between 10400 to 10253.