### PR TITLE
rpc: accept virtual host subdomain wildcards

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -400,7 +400,7 @@ var (
 	}
 	RPCVirtualHostsFlag = cli.StringFlag{
 		Name:  "rpcvhosts",
-		Usage: "Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.",
+		Usage: "Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts global ('*') or subdomain ('*.example.com') wildcards.",
 		Value: "localhost",
 	}
 	RPCApiFlag = cli.StringFlag{


### PR DESCRIPTION
This PR allows white listing virtual hosts (`-rpcvhosts`) with a subdomain wildcard, e.g. `*.gochain.io` or `*.testnet.gochain.io`.