### PR TITLE
trie: use single-sum hash

### DIFF
--- a/trie/hasher.go
+++ b/trie/hasher.go
@@ -37,7 +37,7 @@ type hasher struct {
 // hashers live in a global db.
 var hasherPool = sync.Pool{
 	New: func() interface{} {
-		return &hasher{tmp: new(bytes.Buffer), sha: sha3.NewKeccak256()}
+		return &hasher{tmp: new(bytes.Buffer), sha: sha3.NewKeccak256SingleSum()}
 	},
 }
 


### PR DESCRIPTION
Another place to use single-sum hash and reduce allocations:
```
benchmark                                    old allocs     new allocs     delta
BenchmarkStateProcessor_Process/____1-4      263            253            -3.80%
BenchmarkStateProcessor_Process/___10-4      1271           1243           -2.20%
BenchmarkStateProcessor_Process/__100-4      11351          11143          -1.83%
BenchmarkStateProcessor_Process/_1000-4      112153         110144         -1.79%
BenchmarkStateProcessor_Process/_10000-4     1479690        1456637        -1.56%

benchmark                                    old bytes     new bytes     delta
BenchmarkStateProcessor_Process/____1-4      49057         44577         -9.13%
BenchmarkStateProcessor_Process/___10-4      105870        93325         -11.85%
BenchmarkStateProcessor_Process/__100-4      674095        580911        -13.82%
BenchmarkStateProcessor_Process/_1000-4      6355485       5456611       -14.14%
BenchmarkStateProcessor_Process/_10000-4     88290144      79093496      -10.42%
```