### PR TITLE
core: log 'Failed to add journaled tx' metrics, rather than individual (uninformative) errors

### DIFF
--- a/core/tx_journal.go
+++ b/core/tx_journal.go
@@ -82,9 +82,7 @@ func (journal *txJournal) load(add func(types.Transactions) []error) error {
 	addBatch := func() {
 		if errs := add(batch); len(errs) > 0 {
 			dropped += len(errs)
-			for err := range errs {
-				log.Debug("Failed to add journaled transaction", "err", err)
-			}
+			log.Debug("Failed to add journaled transactions", "errs", len(errs))
 		}
 		batch = batch[:0]
 	}


### PR DESCRIPTION
The logs are often flooded with "Failed to add journaled transaction" errors on startup. These are logged per individual tx, so they are very noisy (potentially 100,000s) and it was buggy. More useful error details can be obtained by turning on trace logging, so these are redundant anyways. With this change, we log the count of errors per batch, instead of each individual error.