### PR TITLE
cmd, console: support SIGTERM in addition to SIGINT

### DIFF
--- a/cmd/gochain/consolecmd.go
+++ b/cmd/gochain/consolecmd.go
@@ -22,6 +22,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/gochain-io/gochain/cmd/utils"
 	"github.com/gochain-io/gochain/console"
@@ -207,7 +208,7 @@ func ephemeralConsole(ctx *cli.Context) error {
 	}
 	// Wait for pending callbacks, but stop for Ctrl-C.
 	abort := make(chan os.Signal, 1)
-	signal.Notify(abort, os.Interrupt)
+	signal.Notify(abort, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
 		<-abort

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -26,6 +26,7 @@ import (
 	"os/signal"
 	"runtime"
 	"strings"
+	"syscall"
 
 	"github.com/gochain-io/gochain/core"
 	"github.com/gochain-io/gochain/core/types"
@@ -65,7 +66,7 @@ func StartNode(ctx context.Context, stack *node.Node) {
 	}
 	go func() {
 		sigc := make(chan os.Signal, 1)
-		signal.Notify(sigc, os.Interrupt)
+		signal.Notify(sigc, syscall.SIGINT, syscall.SIGTERM)
 		defer signal.Stop(sigc)
 		<-sigc
 		log.Info("Got interrupt, shutting down...")
@@ -86,7 +87,7 @@ func ImportChain(ctx context.Context, chain *core.BlockChain, fn string) error {
 	// If a signal is received, the import will stop at the next batch.
 	interrupt := make(chan os.Signal, 1)
 	stop := make(chan struct{})
-	signal.Notify(interrupt, os.Interrupt)
+	signal.Notify(interrupt, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(interrupt)
 	defer close(interrupt)
 	go func() {

--- a/console/console.go
+++ b/console/console.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"syscall"
 
 	"github.com/gochain-io/gochain/internal/jsre"
 	"github.com/gochain-io/gochain/internal/web3ext"
@@ -332,7 +333,7 @@ func (c *Console) Interactive() {
 	}()
 	// Monitor Ctrl-C too in case the input is empty and we need to bail
 	abort := make(chan os.Signal, 1)
-	signal.Notify(abort, os.Interrupt)
+	signal.Notify(abort, syscall.SIGINT, syscall.SIGTERM)
 
 	// Start sending prompts to the user and reading back inputs
 	for {


### PR DESCRIPTION
This PR pulls https://github.com/ethereum/go-ethereum/pull/16142/commits/01507d9b9d872aa6dfaf3ad704b8c2b65e378a41 from upstream, in order to support graceful termination from SIGTERM, not just SIGINT.