### PR TITLE
ethdb, eth, core: archive old chaindata to s3 compatible bucket

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,8 +17,8 @@
     "storage",
     "version"
   ]
-  revision = "b7fadebe0e7f5c5720986080a01495bd8d27be37"
-  version = "v14.2.0"
+  revision = "56a0b1d2af3b65d5f1f7a330e02faaf48b473c5a"
+  version = "v14.6.0"
 
 [[projects]]
   name = "github.com/Azure/go-autorest"
@@ -28,8 +28,8 @@
     "autorest/azure",
     "autorest/date"
   ]
-  revision = "0ae36a9e544696de46fdadb7b0d5fb38af48c063"
-  version = "v10.2.0"
+  revision = "ed4b7f5bf1ec0c9ede1fda2681d96771282f2862"
+  version = "v10.4.0"
 
 [[projects]]
   name = "github.com/StackExchange/wmi"
@@ -41,7 +41,7 @@
   branch = "master"
   name = "github.com/aristanetworks/goarista"
   packages = ["monotime"]
-  revision = "94ff7b94cb7ddd528740cfc9c062037c2bc73b2d"
+  revision = "c4abbbe01ef7ae5ffd295b3a85493582e704cfa2"
 
 [[projects]]
   branch = "master"
@@ -64,14 +64,20 @@
 [[projects]]
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
-  revision = "dbeaa9332f19a944acb5736b4456cfcc02140e29"
-  version = "v3.1.0"
+  revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
+  version = "v3.2.0"
 
 [[projects]]
   name = "github.com/docker/docker"
   packages = ["pkg/reexec"]
   revision = "092cba3727bb9b4a2f0e922cd6c0f93ea270e363"
   version = "v1.13.1"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/dustin/go-humanize"
+  packages = ["."]
+  revision = "bb3d318650d48840a39aa21a027c6630e198e626"
 
 [[projects]]
   branch = "master"
@@ -86,7 +92,7 @@
     ".",
     "sys/windows"
   ]
-  revision = "01b55aeacddd04369e674d32e0eb9a3e7e4394fe"
+  revision = "1784bf412e8794999ebc58e5e39a108d7d4fe565"
 
 [[projects]]
   name = "github.com/fatih/color"
@@ -99,6 +105,12 @@
   packages = ["."]
   revision = "24acd523c756fd9728824cdfac66aad9d8982fb7"
   version = "v2.2.0"
+
+[[projects]]
+  name = "github.com/go-ini/ini"
+  packages = ["."]
+  revision = "6333e38ac20b8949a8dd68baa3650f4dee8f39f0"
+  version = "v1.33.0"
 
 [[projects]]
   name = "github.com/go-ole/go-ole"
@@ -151,7 +163,7 @@
     "soap",
     "ssdp"
   ]
-  revision = "e25a5cc217cad359cb2c52d1529d5ad7489752c2"
+  revision = "167b9766e52022410644dfc64e8aadd57ee36858"
 
 [[projects]]
   name = "github.com/jackpal/go-nat-pmp"
@@ -180,8 +192,8 @@
 [[projects]]
   name = "github.com/maruel/panicparse"
   packages = ["stack"]
-  revision = "766956aceb8ff49664065ae50bef0ae8a0a83ec4"
-  version = "v1.0.2"
+  revision = "785840568bdc7faa0dfb1cd6c643207f03271f64"
+  version = "v1.1.1"
 
 [[projects]]
   name = "github.com/mattn/go-colorable"
@@ -200,6 +212,26 @@
   packages = ["."]
   revision = "9e777a8366cce605130a531d2cd6363d07ad7317"
   version = "v0.0.2"
+
+[[projects]]
+  name = "github.com/minio/minio-go"
+  packages = [
+    ".",
+    "pkg/credentials",
+    "pkg/encrypt",
+    "pkg/policy",
+    "pkg/s3signer",
+    "pkg/s3utils",
+    "pkg/set"
+  ]
+  revision = "66252c2a3c15f7b90cc8493d497a04ac3b6e3606"
+  version = "5.0.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/mitchellh/go-homedir"
+  packages = ["."]
+  revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
 
 [[projects]]
   branch = "master"
@@ -244,7 +276,7 @@
   branch = "master"
   name = "github.com/peterh/liner"
   packages = ["."]
-  revision = "161ea9c37d6d4e97afe7f8f9cde7e647d49bd091"
+  revision = "6106ee4fe3e8435f18cd10e34557e5e50f0e792a"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -277,7 +309,7 @@
   branch = "master"
   name = "github.com/rjeczalik/notify"
   packages = ["."]
-  revision = "c31e5f2cb22b3e4ef3f882f413847669bf2652b9"
+  revision = "d152f3ce359a5464dc41e84a8919fc67e55bbbf0"
 
 [[projects]]
   branch = "master"
@@ -304,6 +336,12 @@
   packages = ["."]
   revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
   version = "v1.2.0"
+
+[[projects]]
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
+  version = "v1.0.5"
 
 [[projects]]
   name = "github.com/stretchr/testify"
@@ -337,6 +375,8 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = [
+    "argon2",
+    "blake2b",
     "cast5",
     "curve25519",
     "ed25519",
@@ -355,7 +395,7 @@
     "ssh",
     "ssh/terminal"
   ]
-  revision = "85f98707c97e11569271e4d9b3d397e079c4f4d0"
+  revision = "88942b9c40a4c9d203b82b3731787b672d6e809b"
 
 [[projects]]
   branch = "master"
@@ -365,15 +405,17 @@
     "html",
     "html/atom",
     "html/charset",
+    "idna",
+    "lex/httplex",
     "websocket"
   ]
-  revision = "07e8617a6db2368fa55d4616f371ee1b1403c817"
+  revision = "6078986fec03a1dcc236c34816c71b0e05018fda"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sync"
   packages = ["syncmap"]
-  revision = "fd80eb99c8f653c847d294a001bdf2a3a6f768f5"
+  revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
 
 [[projects]]
   branch = "master"
@@ -382,11 +424,13 @@
     "unix",
     "windows"
   ]
-  revision = "349b81fb5c64ec1734eb6ee148df25459ea48517"
+  revision = "13d03a9a82fba647c21a0ef8fba44a795d0f0835"
 
 [[projects]]
   name = "golang.org/x/text"
   packages = [
+    "collate",
+    "collate/build",
     "encoding",
     "encoding/charmap",
     "encoding/htmlindex",
@@ -397,13 +441,20 @@
     "encoding/simplifiedchinese",
     "encoding/traditionalchinese",
     "encoding/unicode",
+    "internal/colltab",
     "internal/gen",
     "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
     "internal/utf8internal",
     "language",
     "runes",
+    "secure/bidirule",
     "transform",
-    "unicode/cldr"
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable"
   ]
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
@@ -415,7 +466,7 @@
     "go/ast/astutil",
     "imports"
   ]
-  revision = "059bec968c61383b574810040ba9410712de36c5"
+  revision = "77106db15f689a60e7d4e085d967ac557b918fb2"
 
 [[projects]]
   branch = "v1"
@@ -465,6 +516,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "185851cd1c75df156b6813b7ea082cbbd515fe5580ec61cda44cd3bc8c777cdf"
+  inputs-digest = "1def6cfd50eac90b3f2fa0cca996a49fc9aa52871f338eb09d86c9e54415074b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/gochain/main.go
+++ b/cmd/gochain/main.go
@@ -123,6 +123,12 @@ var (
 		utils.GpoBlocksFlag,
 		utils.GpoPercentileFlag,
 		utils.ExtraDataFlag,
+		utils.ArchiveEndpointFlag,
+		utils.ArchiveBucketFlag,
+		utils.ArchiveIDFlag,
+		utils.ArchiveSecretFlag,
+		utils.ArchiveAgeFlag,
+		utils.ArchivePeriodFlag,
 		configFileFlag,
 	}
 

--- a/cmd/gochain/usage.go
+++ b/cmd/gochain/usage.go
@@ -223,6 +223,17 @@ var AppHelpFlagGroups = []flagGroup{
 		},
 	},
 	{
+		Name: "ARCHIVE",
+		Flags: []cli.Flag{
+			utils.ArchiveEndpointFlag,
+			utils.ArchiveBucketFlag,
+			utils.ArchiveIDFlag,
+			utils.ArchiveSecretFlag,
+			utils.ArchiveAgeFlag,
+			utils.ArchivePeriodFlag,
+		},
+	},
+	{
 		Name: "MISC",
 	},
 }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gochain-io/gochain/eth/downloader"
 	"github.com/gochain-io/gochain/eth/gasprice"
 	"github.com/gochain-io/gochain/ethdb"
+	"github.com/gochain-io/gochain/ethdb/archive"
 	"github.com/gochain-io/gochain/ethstats"
 	"github.com/gochain-io/gochain/les"
 	"github.com/gochain-io/gochain/log"
@@ -538,6 +539,34 @@ var (
 		Usage: "Minimum POW accepted",
 		Value: whisper.DefaultMinimumPoW,
 	}
+
+	// Archive settings
+	ArchiveEndpointFlag = cli.StringFlag{
+		Name:  "archive",
+		Usage: "S3 compatible archive endpoint.",
+	}
+	ArchiveBucketFlag = cli.StringFlag{
+		Name:  "archivebucket",
+		Usage: "Name of archive bucket. Must already exist.",
+	}
+	ArchiveIDFlag = cli.StringFlag{
+		Name:  "archiveid",
+		Usage: "Archive access key ID.",
+	}
+	ArchiveSecretFlag = cli.StringFlag{
+		Name:  "archivesecret",
+		Usage: "Archive access key secret.",
+	}
+	ArchiveAgeFlag = cli.Uint64Flag{
+		Name:  "archiveage",
+		Usage: "Archive age. The number of blocks from head before archiving.",
+		Value: archive.DefaultArchiveAge,
+	}
+	ArchivePeriodFlag = cli.DurationFlag{
+		Name:  "archiveperiod",
+		Usage: "How often the archive process runs.",
+		Value: archive.DefaultArchivePeriod,
+	}
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating
@@ -963,6 +992,27 @@ func setEthash(ctx *cli.Context, cfg *eth.Config) {
 	}
 }
 
+func setArchive(ctx *cli.Context, cfg *archive.Config) {
+	if ctx.GlobalIsSet(ArchiveEndpointFlag.Name) {
+		cfg.Endpoint = ctx.GlobalString(ArchiveEndpointFlag.Name)
+	}
+	if ctx.GlobalIsSet(ArchiveBucketFlag.Name) {
+		cfg.Bucket = ctx.GlobalString(ArchiveBucketFlag.Name)
+	}
+	if ctx.GlobalIsSet(ArchiveIDFlag.Name) {
+		cfg.ID = ctx.GlobalString(ArchiveIDFlag.Name)
+	}
+	if ctx.GlobalIsSet(ArchiveSecretFlag.Name) {
+		cfg.Secret = ctx.GlobalString(ArchiveSecretFlag.Name)
+	}
+	if ctx.GlobalIsSet(ArchiveAgeFlag.Name) {
+		cfg.Age = ctx.GlobalUint64(ArchiveAgeFlag.Name)
+	}
+	if ctx.GlobalIsSet(ArchivePeriodFlag.Name) {
+		cfg.Period = ctx.GlobalDuration(ArchivePeriodFlag.Name)
+	}
+}
+
 // checkExclusive verifies that only a single isntance of the provided flags was
 // set by the user. Each flag might optionally be followed by a string type to
 // specialize it further.
@@ -1024,6 +1074,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	setGPO(ctx, &cfg.GPO)
 	setTxPool(ctx, &cfg.TxPool)
 	setEthash(ctx, cfg)
+	setArchive(ctx, &cfg.Archive)
 
 	switch {
 	case ctx.GlobalIsSet(SyncModeFlag.Name):

--- a/core/database_util_test.go
+++ b/core/database_util_test.go
@@ -402,11 +402,11 @@ func TestNumHashKey(t *testing.T) {
 		},
 		{
 			orig: append(append(prefix, encodeBlockNumber(123456789)...), []byte{numSuffix}...),
-			opt:  numKey(headerPrefix, 123456789),
+			opt:  numKey(123456789),
 		},
 		{
 			orig: append(append(append(prefix, encodeBlockNumber(123456789)...), hash[:]...), []byte{tdSuffix}...),
-			opt:  tdKey(headerPrefix, 123456789, hash),
+			opt:  tdKey(123456789, hash),
 		},
 	} {
 		if !bytes.Equal(test.orig, test.opt) {

--- a/eth/config.go
+++ b/eth/config.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gochain-io/gochain/core"
 	"github.com/gochain-io/gochain/eth/downloader"
 	"github.com/gochain-io/gochain/eth/gasprice"
+	"github.com/gochain-io/gochain/ethdb/archive"
 	"github.com/gochain-io/gochain/params"
 )
 
@@ -114,6 +115,9 @@ type Config struct {
 
 	// Miscellaneous options
 	DocRoot string `toml:"-"`
+
+	// Archive options.
+	Archive archive.Config `toml:",omitempty"`
 }
 
 type configMarshaling struct {

--- a/eth/db_upgrade.go
+++ b/eth/db_upgrade.go
@@ -50,7 +50,7 @@ func upgradeDeduplicateData(db ethdb.Database) func() error {
 
 	go func() {
 		// Create an iterator to read the entire database and covert old lookup entires
-		it := db.(*ethdb.LDBDatabase).NewIterator()
+		it := db.(*ethdb.LDBDatabase).NewIterator(nil, nil)
 		defer func() {
 			if it != nil {
 				it.Release()
@@ -100,7 +100,7 @@ func upgradeDeduplicateData(db ethdb.Database) func() error {
 			converted++
 			if converted%100000 == 0 {
 				it.Release()
-				it = db.(*ethdb.LDBDatabase).NewIterator()
+				it = db.(*ethdb.LDBDatabase).NewIterator(nil, nil)
 				it.Seek(key)
 
 				log.Info("Deduplicating database entries", "deduped", converted)

--- a/eth/filters/bench_test.go
+++ b/eth/filters/bench_test.go
@@ -147,7 +147,7 @@ func benchmarkBloomBits(b *testing.B, sectionSize uint64) {
 }
 
 func forEachKey(db ethdb.Database, startPrefix, endPrefix []byte, fn func(key []byte)) {
-	it := db.(*ethdb.LDBDatabase).NewIterator()
+	it := db.(*ethdb.LDBDatabase).NewIterator(nil, nil)
 	it.Seek(startPrefix)
 	for it.Valid() {
 		key := it.Key()

--- a/ethdb/archive/archive.go
+++ b/ethdb/archive/archive.go
@@ -1,0 +1,321 @@
+package archive
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"time"
+
+	"github.com/minio/minio-go"
+	gometrics "github.com/rcrowley/go-metrics"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/util"
+
+	"github.com/gochain-io/gochain/common"
+	"github.com/gochain-io/gochain/core"
+	"github.com/gochain-io/gochain/ethdb"
+	"github.com/gochain-io/gochain/log"
+	"github.com/gochain-io/gochain/metrics"
+)
+
+const (
+	// DefaultArchiveAge is the default distance from head at which data is archived.
+	DefaultArchiveAge uint64 = 100000
+	// DefaultArchivePeriod is how often the archive process runs.
+	DefaultArchivePeriod = 5 * time.Minute
+)
+
+type Config struct {
+	Endpoint   string        // S3 compatible endpoint.
+	Bucket     string        // Bucket name. Must already exist.
+	ID, Secret string        // Credentials.
+	Age        uint64        // Optional. Distance from head before archiving.
+	Period     time.Duration // Optional. How often to run the archive process.
+}
+
+// Archive manages an archive of data in an S3 compatible bucket.
+type Archive struct {
+	client *minio.Client
+	bucket string
+	age    uint64
+	period time.Duration
+
+	// Meters for measuring archive request counts and latencies.
+	getTimer gometrics.Timer
+	putTimer gometrics.Timer
+	hasTimer gometrics.Timer
+	delTimer gometrics.Timer
+}
+
+// NewArchive returns a new Archive backed by an S3 compatible bucket.
+// The bucket must already exist.
+func NewArchive(config Config) (*Archive, error) {
+	client, err := minio.New(config.Endpoint, config.ID, config.Secret, true)
+	if err != nil {
+		return nil, err
+	}
+	if ok, err := client.BucketExists(config.Bucket); err != nil {
+		return nil, err
+	} else if !ok {
+		return nil, fmt.Errorf("bucket does not exist: %s", config.Bucket)
+	}
+	age := DefaultArchiveAge
+	if config.Age != 0 {
+		age = config.Age
+	}
+	period := DefaultArchivePeriod
+	if config.Period != 0 {
+		period = config.Period
+	}
+	return &Archive{client: client, bucket: config.Bucket, age: age, period: period}, nil
+}
+
+func (a *Archive) Put(key string, value []byte) (int64, error) {
+	if a.putTimer != nil {
+		defer a.putTimer.UpdateSince(time.Now())
+	}
+	return a.client.PutObject(a.bucket, key, bytes.NewReader(value), int64(len(value)), minio.PutObjectOptions{})
+}
+
+func (a *Archive) Get(key string) ([]byte, error) {
+	if a.getTimer != nil {
+		defer a.getTimer.UpdateSince(time.Now())
+	}
+	o, err := a.client.GetObject(a.bucket, key, minio.GetObjectOptions{})
+	if err != nil {
+		return nil, err
+	}
+	defer o.Close()
+	return ioutil.ReadAll(o)
+}
+
+func (a *Archive) Has(key string) (bool, error) {
+	if a.hasTimer != nil {
+		defer a.hasTimer.UpdateSince(time.Now())
+	}
+	_, err := a.client.StatObject(a.bucket, key, minio.StatObjectOptions{})
+	if err != nil {
+		switch er := err.(type) {
+		case minio.ErrorResponse:
+			if er.Code == "NoSuchKey" {
+				return false, nil
+			}
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (a *Archive) Delete(key string) error {
+	if a.delTimer != nil {
+		defer a.delTimer.UpdateSince(time.Now())
+	}
+	return a.client.RemoveObject(a.bucket, key)
+}
+
+func (a *Archive) Meter(prefix string) {
+	if !metrics.Enabled {
+		return
+	}
+	a.getTimer = metrics.NewTimer(prefix + "get")
+	a.putTimer = metrics.NewTimer(prefix + "put")
+	a.hasTimer = metrics.NewTimer(prefix + "has")
+	a.delTimer = metrics.NewTimer(prefix + "del")
+}
+
+func prefixDir(prefix byte) string {
+	switch prefix {
+	case 'h':
+		return "header"
+	case 'b':
+		return "body"
+	case 'r':
+		return "receipts"
+	}
+	return string(prefix)
+}
+
+func archiveKey(prefix byte, num uint64, hash common.Hash) string {
+	return fmt.Sprintf("%s/%d-%s", prefixDir(prefix), num, hash.Hex())
+}
+
+// DB extends an LDBDatabase with support for archiving entries to a
+// Archive.
+type DB struct {
+	*ethdb.LDBDatabase
+	archive *Archive
+
+	done chan struct{} // Closed to signal sweep() to stop.
+	loop chan struct{} // Closed by sweep() when complete.
+}
+
+// NewDB returns a new DB, backed by a Archive.
+// Start() must be called to begin the background archival process.
+func NewDB(db *ethdb.LDBDatabase, archive *Archive) *DB {
+	a := &DB{
+		LDBDatabase: db,
+		archive:     archive,
+		done:        make(chan struct{}),
+		loop:        make(chan struct{})}
+	return a
+}
+
+// Start launches the background goroutine to periodically sweeps for data to archive.
+// It must only be called once.
+func (db *DB) Start(limitFn func(byte) uint64) {
+	go func() {
+		defer close(db.loop)
+		t := time.NewTicker(db.archive.period)
+		defer t.Stop()
+		for {
+			select {
+			case <-db.done:
+				return
+			case <-t.C:
+				db.sweep(limitFn)
+			}
+		}
+	}()
+}
+
+func (db *DB) Close() {
+	close(db.done)
+	db.LDBDatabase.Close()
+	<-db.loop
+}
+
+func (db *DB) Get(key []byte) ([]byte, error) {
+	val, err := db.LDBDatabase.Get(key)
+	if err != nil {
+		if err == leveldb.ErrNotFound {
+			ok, prefix, num, hash := core.DBArchiveKey(key)
+			if ok {
+				arKey := archiveKey(prefix, num, hash)
+				val, err := db.archive.Get(arKey)
+				if err != nil {
+					return nil, err
+				}
+				_ = db.LDBDatabase.Put(key, val)
+				return val, nil
+			}
+		}
+		return nil, err
+	}
+	return val, nil
+}
+
+func (db *DB) Has(key []byte) (bool, error) {
+	if ok, err := db.LDBDatabase.Has(key); err != nil {
+		return false, err
+	} else if ok {
+		return true, nil
+	}
+	ok, prefix, num, hash := core.DBArchiveKey(key)
+	if ok {
+		arKey := archiveKey(prefix, num, hash)
+		return db.archive.Has(arKey)
+	}
+	return false, nil
+}
+
+func (db *DB) Delete(key []byte) error {
+	ok, prefix, num, hash := core.DBArchiveKey(key)
+	if ok {
+		arKey := archiveKey(prefix, num, hash)
+		if err := db.archive.Delete(arKey); err != nil {
+			return err
+		}
+	}
+	return db.LDBDatabase.Delete(key)
+}
+
+// sweep archives data older than latest - DefaultArchiveAge.
+func (db *DB) sweep(latest func(byte) uint64) {
+	log.Info("Archive sweep started")
+	type ret struct {
+		entries    int
+		totalBytes int64
+	}
+	var total ret
+	retCnt := len(core.DBArchivePrefixes)
+	retCh := make(chan ret, retCnt)
+	for _, prefix := range core.DBArchivePrefixes {
+		limit := latest(prefix) - db.archive.age
+		if limit < 0 {
+			retCnt--
+			log.Info("Archive skipped", "type", prefixDir(prefix))
+			continue
+		}
+		go func(prefix byte, limit uint64) {
+			e, b := db.sweepPrefix(prefix, limit)
+			retCh <- ret{entries: e, totalBytes: b}
+		}(prefix, limit)
+	}
+wait:
+	for {
+		select {
+		case <-db.done:
+			log.Info("Archive sweep cancelled")
+			return
+		case cnt := <-retCh:
+			total.entries += cnt.entries
+			total.totalBytes += cnt.totalBytes
+			retCnt--
+			if retCnt == 0 {
+				close(retCh)
+				break wait
+			}
+		}
+	}
+	log.Info("Archive sweep finished", "count", total.entries, "size", common.StorageSize(total.totalBytes))
+}
+
+const sweepUpdateFreq = 1000
+
+// sweepPrefix archives keys with the given prefix, which are older than limit.
+func (db *DB) sweepPrefix(prefix byte, limit uint64) (int, int64) {
+	log.Info("Archive worker started", "type", prefixDir(prefix), "limit", limit)
+	var entries int
+	var totalBytes int64
+	i := db.LDBDatabase.NewIterator(util.BytesPrefix([]byte{prefix}), nil)
+	for i.Next() {
+		select {
+		case <-db.done:
+			break
+		default:
+		}
+		key := i.Key()
+		if len(key) < 9 {
+			continue
+		}
+		ok, _, num, hash := core.DBArchiveKey(key)
+		if !ok {
+			continue
+		}
+		arKey := archiveKey(prefix, num, hash)
+		if num < limit {
+			if n, err := db.archive.Put(arKey, i.Value()); err != nil {
+				log.Info("Archive entry failed", "key", arKey, "err", err)
+			} else {
+				entries++
+				totalBytes += n
+				if entries%sweepUpdateFreq == 0 {
+					log.Info("Archive worker status update", "type", prefixDir(prefix), "limit", limit, "count", entries, "size", common.StorageSize(totalBytes))
+				}
+				if err := db.LDBDatabase.Delete(key); err != nil {
+					// Note but move on. DB still consistent, and future run will clean up.
+					log.Info("Archive entry successful, but failed local deletion", "key", arKey, "err", err)
+				}
+			}
+		} else {
+			// Everything left is more recent, so we're done.
+			break
+		}
+	}
+	i.Release()
+	err := i.Error()
+	if err != nil {
+		log.Warn("Archive worker failed", "type", prefixDir(prefix), "limit", limit, "err", err)
+	}
+	return entries, totalBytes
+}

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -24,13 +24,13 @@ import (
 
 	"github.com/gochain-io/gochain/log"
 	"github.com/gochain-io/gochain/metrics"
+	gometrics "github.com/rcrowley/go-metrics"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/errors"
 	"github.com/syndtr/goleveldb/leveldb/filter"
 	"github.com/syndtr/goleveldb/leveldb/iterator"
 	"github.com/syndtr/goleveldb/leveldb/opt"
-
-	gometrics "github.com/rcrowley/go-metrics"
+	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
 var OpenFileLimit = 64
@@ -145,8 +145,8 @@ func (db *LDBDatabase) Delete(key []byte) error {
 	return db.db.Delete(key, nil)
 }
 
-func (db *LDBDatabase) NewIterator() iterator.Iterator {
-	return db.db.NewIterator(nil, nil)
+func (db *LDBDatabase) NewIterator(slice *util.Range, ro *opt.ReadOptions) iterator.Iterator {
+	return db.db.NewIterator(slice, ro)
 }
 
 func (db *LDBDatabase) Close() {


### PR DESCRIPTION
This PR adds the option to archive old chaindata from leveldb to an s3 compatible bucket. The archive is enabled by setting the following flags:
```
ARCHIVE OPTIONS:
  --archive value        S3 compatible archive endpoint.
  --archivebucket value  Name of archive bucket. Must already exist.
  --archiveid value      Archive access key ID.
  --archivesecret value  Archive access key secret.
  --archiveage value     Archive age. The number of blocks from head before archiving. (default: 100000)
  --archiveperiod value  How often the archive process runs. (default: 5m0s)
```
When the archive is enabled, a background process periodically sweeps leveldb for data to archive. Currently this is header, body, and receipts data older than `100000` blocks from the current head.

The archive emits metrics (if enabled) as `db/archive/chaindata/*`, similar to the existing levedb metrics under `db/chaindata/*`, for comparison.

#100 