### PR TITLE
eth: increase txsyncPackSize x10 to send fewer, larger packets of pooled txs

### DIFF
--- a/eth/sync.go
+++ b/eth/sync.go
@@ -35,7 +35,7 @@ const (
 
 	// This is the target size for the packs of transactions sent by txsyncLoop.
 	// A pack can get larger than this if a single transactions exceeds this size.
-	txsyncPackSize = 100 * 1024
+	txsyncPackSize = 1000 * 1024
 )
 
 type txsync struct {


### PR DESCRIPTION
Some recent metrics show roughly equal volume of data being shared with peers via _block_ packets and _tx sync_ packets (pooled txs).

![screenshot from 2018-04-17 15-32-19](https://user-images.githubusercontent.com/1194128/38895042-92f39d38-4254-11e8-9cdf-34d1fd276704.png)
![screenshot from 2018-04-17 15-32-14](https://user-images.githubusercontent.com/1194128/38895043-9301e582-4254-11e8-9085-29e39d06c36d.png)

However, there is a drastic difference in the number of packets -
there are roughly 1000-2000 times as many _tx sync_ packets as _block_ packets (e.g. 2k/sec on some test nodes as I write this).

![screenshot from 2018-04-17 15-33-18](https://user-images.githubusercontent.com/1194128/38895090-aebfde96-4254-11e8-869f-41c155697cb0.png)
![screenshot from 2018-04-17 15-33-13](https://user-images.githubusercontent.com/1194128/38895091-aecf3878-4254-11e8-8f9f-12217fd4e2a7.png)


This change increase the `txsyncPackSize` x10, which directly determines the size of the _tx sync_ packets (e.g. 200/sec expected). The goal is to improve how quickly the proxies feed pooled txs to the signers. There may also be some speedup in tx pool performance from loading larger batches.