### PR TITLE
support archive configuration from config.toml

### DIFF
--- a/eth/gen_config.go
+++ b/eth/gen_config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gochain-io/gochain/core"
 	"github.com/gochain-io/gochain/eth/downloader"
 	"github.com/gochain-io/gochain/eth/gasprice"
+	"github.com/gochain-io/gochain/ethdb/archive"
 )
 
 var _ = (*configMarshaling)(nil)
@@ -31,6 +32,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		GasPrice                *big.Int
 		Ethash                  ethash.Config
 		TxPool                  core.TxPoolConfig
+		Archive                 archive.Config `toml:",omitempty"`
 		GPO                     gasprice.Config
 		EnablePreimageRecording bool
 		DocRoot                 string `toml:"-"`
@@ -50,6 +52,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.GasPrice = c.GasPrice
 	enc.Ethash = c.Ethash
 	enc.TxPool = c.TxPool
+	enc.Archive = c.Archive
 	enc.GPO = c.GPO
 	enc.EnablePreimageRecording = c.EnablePreimageRecording
 	enc.DocRoot = c.DocRoot
@@ -72,6 +75,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		GasPrice                *big.Int
 		Ethash                  *ethash.Config
 		TxPool                  *core.TxPoolConfig
+		Archive                 *archive.Config `toml:",omitempty"`
 		GPO                     *gasprice.Config
 		EnablePreimageRecording *bool
 		DocRoot                 *string `toml:"-"`
@@ -121,6 +125,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.TxPool != nil {
 		c.TxPool = *dec.TxPool
+	}
+	if dec.Archive != nil {
+		c.Archive = *dec.Archive
 	}
 	if dec.GPO != nil {
 		c.GPO = *dec.GPO

--- a/ethdb/archive/archive.go
+++ b/ethdb/archive/archive.go
@@ -26,11 +26,11 @@ const (
 )
 
 type Config struct {
-	Endpoint   string        // S3 compatible endpoint.
-	Bucket     string        // Bucket name. Must already exist.
-	ID, Secret string        // Credentials.
-	Age        uint64        // Optional. Distance from head before archiving.
-	Period     time.Duration // Optional. How often to run the archive process.
+	Endpoint   string        `toml:",omitempty"` // S3 compatible endpoint.
+	Bucket     string        `toml:",omitempty"` // Bucket name. Must already exist.
+	ID, Secret string        `toml:",omitempty"` // Credentials.
+	Age        uint64        `toml:",omitempty"` // Optional. Distance from head before archiving.
+	Period     time.Duration `toml:",omitempty"` // Optional. How often to run the archive process.
 }
 
 // Archive manages an archive of data in an S3 compatible bucket.


### PR DESCRIPTION
This change adds support for configuring the archive from the `.toml` file, instead of only via flags.

Flag example:
```
command: gochain --config config.toml --archive storage.website --archiveage 1000 --archivebucket bucket-name --archiveid 5das65f4sdf321df --archivesecret asdf1234ghtradf32df456ds6
```
`.toml` example:
```toml
[Eth.Archive]
Endpoint = "storage.website"
Bucket = "bucket-name"
ID = "5das65f4sdf321df"
Secret = "asdf1234ghtradf32df456ds6"
Age = 1000
```