### PR TITLE
core: reduce global pool limits by half

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -160,9 +160,9 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	PriceBump:  10,
 
 	AccountSlots: 512,
-	GlobalSlots:  131072,
+	GlobalSlots:  65536,
 	AccountQueue: 2048,
-	GlobalQueue:  32768,
+	GlobalQueue:  16384,
 
 	Lifetime: 3 * time.Hour,
 }


### PR DESCRIPTION
This PR cuts the global pool limits in half (from values we raised a few weeks ago - still much higher than geth defaults). The pools are generally not anywhere near this 50% point when healthy and almost never go above it unless they've fallen behind, which is then worsened by a growing pool. They still generally fill all the way up, and then reject requests anyways. We're better off hitting the limit and rejecting a bit sooner, in order to recover more quickly and efficiently.
Trial run via flags on testnet-proxy1 shows less RPC time explosions (pending balance, pending nonce).