### PR TITLE
core: reduce pool limits to 8x originals

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -159,10 +159,10 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	PriceLimit: 1,
 	PriceBump:  10,
 
-	AccountSlots: 512,
-	GlobalSlots:  65536,
-	AccountQueue: 2048,
-	GlobalQueue:  16384,
+	AccountSlots: 128,
+	GlobalSlots:  32768,
+	AccountQueue: 512,
+	GlobalQueue:  8192,
 
 	Lifetime: 3 * time.Hour,
 }


### PR DESCRIPTION
Halved the globals again, and reduced the per-accounts as well to restore original ratios. They are all now 8x the original geth settings.