### PR TITLE
core: Check txn length when building a transaction set.

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -381,10 +381,12 @@ func NewTransactionsByPriceAndNonce(ctx context.Context, signer Signer, txs map[
 	// Initialize a price based heap with the head transactions
 	heads := make(TxByPrice, 0, len(txs))
 	for _, accTxs := range txs {
-		heads = append(heads, accTxs[0])
-		// Ensure the sender address is from the signer
-		acc, _ := Sender(ctx, signer, accTxs[0])
-		txs[acc] = accTxs[1:]
+		if len(accTxs) > 0 {
+			heads = append(heads, accTxs[0])
+			// Ensure the sender address is from the signer
+			acc, _ := Sender(ctx, signer, accTxs[0])
+			txs[acc] = accTxs[1:]
+		}
 	}
 	heap.Init(&heads)
 


### PR DESCRIPTION
The issue in #121 is caused by a `txList` being added in the pending transaction pool but no transactions are actually added to it. This performs a check when building the transaction list.