### PR TITLE
ethdb: Implement segmented state database.

### DIFF
--- a/ethdb/interface.go
+++ b/ethdb/interface.go
@@ -35,6 +35,14 @@ type Database interface {
 	NewBatch() Batch
 }
 
+// NewDatabaseFunc represents a function for generating a new database.
+type NewDatabaseFunc func(NewDatabaseOptions) (Database, error)
+
+// NewDatabaseOptions represents options passed to NewDatabaseFunc.
+type NewDatabaseOptions struct {
+	Path string // on-disk path
+}
+
 // Batch is a write-only database that commits changes to its host database
 // when Write is called. Batch cannot be used concurrently.
 type Batch interface {

--- a/ethdb/segmented_database.go
+++ b/ethdb/segmented_database.go
@@ -1,0 +1,184 @@
+package ethdb
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"sync"
+
+	"github.com/gochain-io/gochain/log"
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+var (
+	ErrInvalidSegmentFilename = errors.New("invalid segment filename")
+)
+
+// SegmentedDatabase represents a database segmented by block number.
+// Each segment contains data for a different block number.
+type SegmentedDatabase struct {
+	mu       sync.RWMutex
+	global   Database                    // All data not segmented by block number
+	segments map[uint64]*DatabaseSegment // Lookup of segments by block number.
+	log      log.Logger                  // Contextual logger tracking the database path
+
+	// Filename of the root database directory.
+	Path string
+
+	// Generates a new instance of Database for a segment.
+	NewDatabase NewDatabaseFunc
+}
+
+// NewSegmentedDatabase returns a new instance of SegmentedDatabase.
+func NewSegmentedDatabase(path string) (*SegmentedDatabase, error) {
+	global, err := NewLDBDatabase(filepath.Join(path, "global"), 0, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SegmentedDatabase{
+		global:   global,
+		segments: make(map[uint64]*DatabaseSegment),
+		log:      log.New("database", path),
+
+		Path: path,
+	}, nil
+}
+
+// Close closes all global and segment databases.
+func (db *SegmentedDatabase) Close() {
+	db.global.Close()
+	for _, seg := range db.segments {
+		seg.db.Close()
+	}
+}
+
+// Segment finds a segment by block number.
+func (db *SegmentedDatabase) Segment(num uint64) *DatabaseSegment {
+	db.mu.RLock()
+	seg := db.segments[num]
+	db.mu.RUnlock()
+	return seg
+}
+
+// CreateSegmentIfNotExists finds or creates a segment by block number.
+func (db *SegmentedDatabase) CreateSegmentIfNotExists(num uint64) (*DatabaseSegment, error) {
+	// Attempt to find segment under read lock.
+	if seg := db.Segment(num); seg != nil {
+		return seg, nil
+	}
+
+	// Recheck under write lock and create if it doesn't exist.
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	if seg := db.segments[num]; seg != nil {
+		return seg, nil
+	}
+
+	// Generate a database for the segment.
+	sdb, err := db.NewDatabase(NewDatabaseOptions{Path: filepath.Join(db.Path, FormatSegmentFilename(num))})
+	if err != nil {
+		return nil, err
+	}
+
+	seg := NewDatabaseSegment(num, sdb)
+	db.segments[num] = seg
+	return seg, nil
+}
+
+// Put writes the key/value pair to the database.
+func (db *SegmentedDatabase) Put(key, value []byte) error {
+	num, ok := KeyBlockNumber(key)
+	if !ok {
+		return db.global.Put(key, value)
+	}
+
+	seg, err := db.CreateSegmentIfNotExists(num)
+	if err != nil {
+		return err
+	}
+	return seg.db.Put(key, value)
+}
+
+// Has returns true if key exists.
+func (db *SegmentedDatabase) Has(key []byte) (bool, error) {
+	num, ok := KeyBlockNumber(key)
+	if !ok {
+		return db.global.Has(key)
+	}
+
+	seg := db.Segment(num)
+	if seg == nil {
+		return false, nil
+	}
+	return seg.db.Has(key)
+}
+
+// Get returns the value of a given key.
+func (db *SegmentedDatabase) Get(key []byte) ([]byte, error) {
+	num, ok := KeyBlockNumber(key)
+	if !ok {
+		return db.global.Get(key)
+	}
+
+	seg := db.Segment(num)
+	if seg == nil {
+		return nil, leveldb.ErrNotFound
+	}
+	return seg.db.Get(key)
+}
+
+// Delete deletes the key from database.
+func (db *SegmentedDatabase) Delete(key []byte) error {
+	num, ok := KeyBlockNumber(key)
+	if !ok {
+		return db.global.Delete(key)
+	}
+
+	seg := db.Segment(num)
+	if seg == nil {
+		return nil
+	}
+	return seg.db.Delete(key)
+}
+
+// DatabaseSegment represents data for single block number.
+type DatabaseSegment struct {
+	blockNumber uint64
+	db          Database
+}
+
+// NewDatabaseSegment returns a new instance of DatabaseSegment.
+func NewDatabaseSegment(blockNumber uint64, db Database) *DatabaseSegment {
+	return &DatabaseSegment{blockNumber: blockNumber, db: db}
+}
+
+// KeyBlockNumber returns the block number for a given key and returns ok true.
+// If the key does not encode the block number then ok is false.
+func KeyBlockNumber(key []byte) (num uint64, ok bool) {
+	if len(key) < 9 {
+		return 0, false
+	}
+	switch key[0] {
+	case 'h', 't', 'n', 'b', 'r': // copied from core/database_util.go
+		return binary.BigEndian.Uint64(key[1:9]), true
+	default:
+		return 0, false
+	}
+}
+
+// FormatSegmentFilename returns a segment filename.
+func FormatSegmentFilename(blockNumber uint64) string {
+	return fmt.Sprintf("%016x", blockNumber)
+}
+
+// ParseSegmentFilename returns a block number for a given segment filename.
+func ParseSegmentFilename(filename string) (uint64, error) {
+	blockNumber, err := strconv.ParseUint(filename, 16, 64)
+	if err != nil {
+		return 0, ErrInvalidSegmentFilename
+	}
+	return blockNumber, nil
+}

--- a/ethdb/segmented_database_test.go
+++ b/ethdb/segmented_database_test.go
@@ -1,0 +1,281 @@
+package ethdb_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gochain-io/gochain/common"
+	"github.com/gochain-io/gochain/ethdb"
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+func TestSegmentedDatabase_Put(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		db := MustNewSegmentedDatabase()
+		defer MustCloseSegmentedDatabase(db)
+		key := numHashKey('h', 18372, common.Hash{})
+
+		// Insert new key/value.
+		if err := db.Put(key, []byte("xyz")); err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify it exists.
+		if ok, err := db.Has(key); err != nil {
+			t.Fatal(err)
+		} else if !ok {
+			t.Fatal("expected key exists")
+		}
+
+		// Verify its value can be retrieved.
+		if value, err := db.Get(key); err != nil {
+			t.Fatal(err)
+		} else if !bytes.Equal(value, []byte("xyz")) {
+			t.Fatalf("unexpected value: %x", value)
+		}
+
+		// Verify correct segment is created.
+		if _, err := os.Stat(filepath.Join(db.Path, "00000000000047c4")); os.IsNotExist(err) {
+			t.Fatal("expected segment directory to exist")
+		} else if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("Global", func(t *testing.T) {
+		db := MustNewSegmentedDatabase()
+		defer MustCloseSegmentedDatabase(db)
+		key := []byte("foo")
+
+		// Insert new key/value.
+		if err := db.Put(key, []byte("bar")); err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify it exists.
+		if ok, err := db.Has(key); err != nil {
+			t.Fatal(err)
+		} else if !ok {
+			t.Fatal("expected key exists")
+		}
+
+		// Verify its value can be retrieved.
+		if value, err := db.Get(key); err != nil {
+			t.Fatal(err)
+		} else if !bytes.Equal(value, []byte("bar")) {
+			t.Fatalf("unexpected value: %x", value)
+		}
+	})
+}
+
+func TestSegmentedDatabase_Has(t *testing.T) {
+	t.Run("NotFound/NoSegment", func(t *testing.T) {
+		db := MustNewSegmentedDatabase()
+		defer MustCloseSegmentedDatabase(db)
+		if ok, err := db.Has(numHashKey('h', 18372, common.Hash{})); err != nil {
+			t.Fatal(err)
+		} else if ok {
+			t.Fatal("expected not found")
+		}
+	})
+
+	t.Run("NotFound/WithSegment", func(t *testing.T) {
+		db := MustNewSegmentedDatabase()
+		defer MustCloseSegmentedDatabase(db)
+
+		if err := db.Put(numHashKey('t', 18372, common.Hash{}), []byte("xyz")); err != nil {
+			t.Fatal(err)
+		}
+		if ok, err := db.Has(numHashKey('h', 18372, common.Hash{})); err != nil {
+			t.Fatal(err)
+		} else if ok {
+			t.Fatal("expected not found")
+		}
+	})
+
+	t.Run("NotFound/Global", func(t *testing.T) {
+		db := MustNewSegmentedDatabase()
+		defer MustCloseSegmentedDatabase(db)
+
+		if ok, err := db.Has([]byte("foo")); err != nil {
+			t.Fatal(err)
+		} else if ok {
+			t.Fatal("expected not found")
+		}
+	})
+}
+
+func TestSegmentedDatabase_Get(t *testing.T) {
+	t.Run("NotFound/NoSegment", func(t *testing.T) {
+		db := MustNewSegmentedDatabase()
+		defer MustCloseSegmentedDatabase(db)
+		if _, err := db.Get(numHashKey('h', 18372, common.Hash{})); err != leveldb.ErrNotFound {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("NotFound/WithSegment", func(t *testing.T) {
+		db := MustNewSegmentedDatabase()
+		defer MustCloseSegmentedDatabase(db)
+
+		if err := db.Put(numHashKey('t', 18372, common.Hash{}), []byte("xyz")); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.Get(numHashKey('h', 18372, common.Hash{})); err != leveldb.ErrNotFound {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("NotFound/Global", func(t *testing.T) {
+		db := MustNewSegmentedDatabase()
+		defer MustCloseSegmentedDatabase(db)
+
+		if _, err := db.Get([]byte("foo")); err != leveldb.ErrNotFound {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestSegmentedDatabase_Delete(t *testing.T) {
+	t.Run("OK/Segment", func(t *testing.T) {
+		db := MustNewSegmentedDatabase()
+		defer MustCloseSegmentedDatabase(db)
+
+		if err := db.Put(numHashKey('h', 18372, common.Hash{}), []byte("xyz")); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Delete(numHashKey('h', 18372, common.Hash{})); err != nil {
+			t.Fatal(err)
+		}
+		if ok, err := db.Has(numHashKey('h', 18372, common.Hash{})); err != nil {
+			t.Fatal(err)
+		} else if ok {
+			t.Fatal("expected key to be deleted")
+		}
+	})
+
+	t.Run("OK/Global", func(t *testing.T) {
+		db := MustNewSegmentedDatabase()
+		defer MustCloseSegmentedDatabase(db)
+
+		if err := db.Put([]byte("foo"), []byte("xyz")); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Delete([]byte("foo")); err != nil {
+			t.Fatal(err)
+		}
+		if ok, err := db.Has([]byte("foo")); err != nil {
+			t.Fatal(err)
+		} else if ok {
+			t.Fatal("expected key to be deleted")
+		}
+	})
+
+	t.Run("NotFound/NoSegment", func(t *testing.T) {
+		db := MustNewSegmentedDatabase()
+		defer MustCloseSegmentedDatabase(db)
+		if err := db.Delete(numHashKey('h', 18372, common.Hash{})); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("NotFound/WithSegment", func(t *testing.T) {
+		db := MustNewSegmentedDatabase()
+		defer MustCloseSegmentedDatabase(db)
+
+		if err := db.Put(numHashKey('t', 18372, common.Hash{}), []byte("xyz")); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Delete(numHashKey('h', 18372, common.Hash{})); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("NotFound/Global", func(t *testing.T) {
+		db := MustNewSegmentedDatabase()
+		defer MustCloseSegmentedDatabase(db)
+
+		if err := db.Delete([]byte("foo")); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestKeyBlockNumber(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		if num, ok := ethdb.KeyBlockNumber(numHashKey('t', 12346789, common.Hash{})); !ok {
+			t.Fatal("expected ok")
+		} else if num != 12346789 {
+			t.Fatalf("unexpected block number: %d", num)
+		}
+	})
+
+	t.Run("Other", func(t *testing.T) {
+		if num, ok := ethdb.KeyBlockNumber(numHashKey('X', 12346789, common.Hash{})); ok {
+			t.Fatal("expected not ok")
+		} else if num != 0 {
+			t.Fatalf("unexpected block number: %d", num)
+		}
+	})
+
+	t.Run("TooShort", func(t *testing.T) {
+		if num, ok := ethdb.KeyBlockNumber([]byte("t129837")); ok {
+			t.Fatal("expected not ok")
+		} else if num != 0 {
+			t.Fatalf("unexpected block number: %d", num)
+		}
+	})
+}
+
+func TestParseSegmentFilename(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		if num, err := ethdb.ParseSegmentFilename(ethdb.FormatSegmentFilename(912837)); err != nil {
+			t.Fatal(err)
+		} else if num != 912837 {
+			t.Fatalf("unexpected block number: %d", num)
+		}
+	})
+
+	t.Run("ErrInvalidSegmentFilename", func(t *testing.T) {
+		if _, err := ethdb.ParseSegmentFilename("BAD_FILENAME"); err != ethdb.ErrInvalidSegmentFilename {
+			t.Fatalf("unexpected error: %s", err)
+		}
+	})
+}
+
+// MustNewSegmentedDatabase returns a new SegmentedDatabase at a temporary path.
+func MustNewSegmentedDatabase() *ethdb.SegmentedDatabase {
+	path, err := ioutil.TempDir("", "")
+	if err != nil {
+		panic(err)
+	}
+
+	db, err := ethdb.NewSegmentedDatabase(path)
+	if err != nil {
+		panic(err)
+	}
+	db.NewDatabase = func(opt ethdb.NewDatabaseOptions) (ethdb.Database, error) {
+		return ethdb.NewLDBDatabase(opt.Path, 0, 0)
+	}
+	return db
+}
+
+// MustCloseSegmentedDatabase closes and removes the underlying data for db.
+func MustCloseSegmentedDatabase(db *ethdb.SegmentedDatabase) {
+	db.Close()
+	if err := os.RemoveAll(db.Path); err != nil {
+		panic(err)
+	}
+}
+
+func numHashKey(prefix byte, number uint64, hash common.Hash) []byte {
+	var k [41]byte
+	k[0] = prefix
+	binary.BigEndian.PutUint64(k[1:], number)
+	copy(k[9:], hash[:])
+	return k[:]
+}


### PR DESCRIPTION
This pull request implements `ethdb.SegmentedDatabase` for segmenting the state database by block number. It isn't wired into the main application yet but it has full test coverage. It implements `ethdb.Database` so it can be swapped out for `ethdb.LDBDatabase`.

Right now running this would require _way_ too many file descriptors because it has a LevelDB for every block but I'm working on implementing read-only database files next so we don't have that issue.