### PR TITLE
eth: periodically re-sync pending txs with peers

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -215,6 +215,7 @@ func (pm *ProtocolManager) Start(ctx context.Context, maxPeers int) {
 	// start sync handlers
 	go pm.syncer(ctx)
 	go pm.txsyncLoop()
+	go pm.txResyncLoop()
 }
 
 func (pm *ProtocolManager) Stop() {

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -412,6 +412,18 @@ func (ps *peerSet) Len() int {
 	return len(ps.peers)
 }
 
+// All returns all current peers.
+func (ps *peerSet) All() []*peer {
+	ps.lock.RLock()
+	defer ps.lock.RUnlock()
+
+	all := make([]*peer, 0, ps.Len())
+	for _, p := range ps.peers {
+		all = append(all, p)
+	}
+	return all
+}
+
 // PeersWithoutBlock retrieves a list of peers that do not have a given block in
 // their set of known hashes.
 func (ps *peerSet) PeersWithoutBlock(hash common.Hash) []*peer {


### PR DESCRIPTION
This PR adds a goroutine to the `ProtocolManager` which periodically (5m) syncs pending txs with peers, with the same sync mechanism used when adding new peers (batch, instead of single broadcast). This should allow stuck nodes with full pools to become healthy again by rebroadcasting (without a restart).