### PR TITLE
eth: re-sync tx pool every 1m instead of 5m

### DIFF
--- a/eth/sync.go
+++ b/eth/sync.go
@@ -35,7 +35,7 @@ const (
 	// This is the target size for the packs of transactions sent by txsyncLoop.
 	// A pack can get larger than this if a single transactions exceeds this size.
 	txsyncPackSize   = 1000 * 1024
-	txResyncInterval = 5 * time.Minute // How often to re-sync pending txs with peers.
+	txResyncInterval = 1 * time.Minute // How often to re-sync pending txs with peers.
 )
 
 type txsync struct {


### PR DESCRIPTION
This new resync feature is _eventually_ recovering stuck nodes, but could be more responsive, since we still often see periods of several minutes with full pools and no activity before the resync is triggered. This PR reduces the interval from five minutes to one minute. As the interval approaches the block time (5s), the chance of needlessly re-sending txs (which our peers already have and just haven't processed yet) increases, but we're still at 12x blocks with one minute so I'm not too concerned for now.