### PR TITLE
eth: broadcast & resync txs to sqrt(peers); log broadcast errors; only mark known on nil err

### DIFF
--- a/eth/peer.go
+++ b/eth/peer.go
@@ -194,24 +194,32 @@ func (p *peer) MarkTransaction(hash common.Hash) {
 // SendTransactions sends transactions to the peer and includes the hashes
 // in its transaction hash set for future reference.
 func (p *peer) SendTransactions(txs types.Transactions) error {
-	p.knownTxs.AddAll(txs)
-	return p2p.Send(p.rw, TxMsg, txs)
+	err := p2p.Send(p.rw, TxMsg, txs)
+	if err == nil {
+		p.knownTxs.AddAll(txs)
+	}
+	return err
 }
 
 // SendNewBlockHash announces the availability of a number of blocks through
 // a hash notification.
 func (p *peer) SendNewBlockHash(hash common.Hash, number uint64) error {
-	p.knownBlocks.Add(hash)
-
 	data := newBlockHashesData{{Hash: hash, Number: number}}
 
-	return p2p.Send(p.rw, NewBlockHashesMsg, data)
+	err := p2p.Send(p.rw, NewBlockHashesMsg, data)
+	if err == nil {
+		p.knownBlocks.Add(hash)
+	}
+	return err
 }
 
 // SendNewBlock propagates an entire block to a remote peer.
 func (p *peer) SendNewBlock(block *types.Block, td *big.Int) error {
-	p.knownBlocks.Add(block.Hash())
-	return p2p.Send(p.rw, NewBlockMsg, []interface{}{block, td})
+	err := p2p.Send(p.rw, NewBlockMsg, []interface{}{block, td})
+	if err == nil {
+		p.knownBlocks.Add(block.Hash())
+	}
+	return err
 }
 
 // SendBlockHeaders sends a batch of block headers to the remote peer.

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -18,6 +18,7 @@ package eth
 
 import (
 	"context"
+	"math"
 	"sync/atomic"
 	"time"
 
@@ -63,7 +64,9 @@ func (pm *ProtocolManager) syncTransactionsAllPeers() {
 	if len(txs) == 0 {
 		return
 	}
-	for _, p := range pm.peers.All() {
+	peers := pm.peers.All()
+	peers = peers[:int(math.Sqrt(float64(len(peers))))]
+	for _, p := range peers {
 		select {
 		case pm.txsyncCh <- &txsync{p, txs}:
 		case <-pm.quitSync:


### PR DESCRIPTION
This PR makes a few changes:
1) Log ignored errors when broadcasting. (follow up from #137)
2) Only mark txs and blocks as 'known' to a peer _if the send is successful_.
3) Restore tx broadcast to a subset (sqrt) of peers (aligned with blocks). Also resync to subset.

1 and 2 seem like no-brainers, but 3 is optional.