### PR TITLE
eth: update higest block we know during the sync if a higher was foun…

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1300,6 +1300,14 @@ func (d *Downloader) processHeaders(ctx context.Context, origin uint64, pivot ui
 				headers = headers[limit:]
 				origin += uint64(limit)
 			}
+
+			// Update the highest block number we know if a higher one is found.
+			d.syncStatsLock.Lock()
+			if d.syncStatsChainHeight < origin {
+				d.syncStatsChainHeight = origin - 1
+			}
+			d.syncStatsLock.Unlock()
+
 			// Signal the content downloaders of the availablility of new tasks
 			for _, ch := range []chan bool{d.bodyWakeCh, d.receiptWakeCh} {
 				select {

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -209,6 +209,14 @@ func (pm *ProtocolManager) synchronise(ctx context.Context, peer *peer) {
 		atomic.StoreUint32(&pm.fastSync, 1)
 		mode = downloader.FastSync
 	}
+
+	if mode == downloader.FastSync {
+		// Make sure the peer's total difficulty we are synchronizing is higher.
+		if pm.blockchain.GetTdByHash(pm.blockchain.CurrentFastBlock().Hash()).Cmp(pTd) >= 0 {
+			return
+		}
+	}
+
 	// Run the sync cycle, and disable fast sync if we've went past the pivot block
 	if err := pm.downloader.Synchronise(ctx, peer.id, pHead, pTd, mode); err != nil {
 		return


### PR DESCRIPTION
Cherry-pick https://github.com/ethereum/go-ethereum/pull/16283

* eth: update higest block we know during the sync if a higher was found

* eth: avoid useless sync in fast sync