### PR TITLE
eth: clean up parallel send code

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -647,7 +647,7 @@ func (pm *ProtocolManager) BroadcastBlock(block *types.Block, propagate bool) {
 		}
 		// Send the block to a subset of our peers
 		transfer := peers[:int(math.Sqrt(float64(len(peers))))]
-		if err := parallelPeers(transfer).SendNewBlock(block, td); err != nil {
+		if err := SendNewBlockParallel(transfer, block, td); err != nil {
 			log.Error("Cannot send new block", "hash", hash, "number", block.NumberU64(), "err", err)
 		} else {
 			log.Trace("Propagated block", "hash", hash, "recipients", len(transfer), "duration", common.PrettyDuration(time.Since(block.ReceivedAt)))
@@ -656,7 +656,7 @@ func (pm *ProtocolManager) BroadcastBlock(block *types.Block, propagate bool) {
 	}
 	// Otherwise if the block is indeed in out own chain, announce it
 	if pm.blockchain.HasBlock(hash, block.NumberU64()) {
-		if err := parallelPeers(peers).SendNewBlockHash(hash, block.NumberU64()); err != nil {
+		if err := SendNewBlockHashParallel(peers, hash, block.NumberU64()); err != nil {
 			log.Error("Cannot send new block hash", "hash", hash, "number", block.NumberU64(), "err", err)
 		} else {
 			log.Trace("Announced block", "hash", hash, "recipients", len(peers), "duration", common.PrettyDuration(time.Since(block.ReceivedAt)))
@@ -670,7 +670,7 @@ func (pm *ProtocolManager) BroadcastTx(hash common.Hash, tx *types.Transaction) 
 	// Broadcast transaction to a batch of peers not knowing about it
 	peers := pm.peers.PeersWithoutTx(hash)
 	peers = peers[:int(math.Sqrt(float64(len(peers))))]
-	if err := parallelPeers(peers).SendTransaction(tx); err != nil {
+	if err := SendTransactionParallel(peers, tx); err != nil {
 		log.Error("Cannot send transaction", "hash", hash, "err", err)
 	} else if log.Tracing() {
 		log.Trace("Broadcast transaction", "hash", hash, "recipients", len(peers))


### PR DESCRIPTION
Follow up from #147. Just clean up to remove a type - no behavior change.