### PR TITLE
bmt, core, eth, les, light, miner, node, p2p, rpc, trie: Add error checking/logging for most errors.

### DIFF
--- a/bmt/bmt.go
+++ b/bmt/bmt.go
@@ -312,8 +312,8 @@ func (self *Hasher) Sum(b []byte) (r []byte) {
 	}
 	res := self.pool.hasher()
 	res.Reset()
-	res.Write(self.blockLength)
-	res.Write(c)
+	_, _ = res.Write(self.blockLength)
+	_, _ = res.Write(c)
 	return res.Sum(nil)
 }
 
@@ -445,7 +445,7 @@ func (self *Hasher) writeSegment(i int, s []byte, d int) {
 	if len(s) > self.size && n.parent != nil {
 		go func() {
 			h.Reset()
-			h.Write(s)
+			_, _ = h.Write(s)
 			s = h.Sum(nil)
 
 			if n.root {
@@ -472,8 +472,8 @@ func (self *Hasher) run(n *Node, h hash.Hash, d int, i int, s []byte) {
 		}
 		if !n.unbalanced || !isLeft || i == 0 && d == 0 {
 			h.Reset()
-			h.Write(n.left)
-			h.Write(n.right)
+			_, _ = h.Write(n.left)
+			_, _ = h.Write(n.right)
 			s = h.Sum(nil)
 
 		} else {

--- a/bmt/bmt_r.go
+++ b/bmt/bmt_r.go
@@ -78,8 +78,8 @@ func (rh *RefHasher) hash(d []byte, s int) []byte {
 		}
 	}
 	defer rh.h.Reset()
-	rh.h.Write(left)
-	rh.h.Write(right)
+	_, _ = rh.h.Write(left)
+	_, _ = rh.h.Write(right)
 	h := rh.h.Sum(nil)
 	return h
 }

--- a/core/chain_indexer.go
+++ b/core/chain_indexer.go
@@ -406,7 +406,9 @@ func (c *ChainIndexer) setValidSections(sections uint64) {
 	// Set the current number of valid sections in the database
 	var data [8]byte
 	binary.BigEndian.PutUint64(data[:], sections)
-	c.indexDb.Put([]byte("count"), data[:])
+	if err := c.indexDb.Put([]byte("count"), data[:]); err != nil {
+		log.Error("Cannot set chain indexer valid sections count", "sections", sections, "err", err)
+	}
 
 	// Remove any reorged sections, caching the valids in the mean time
 	for c.storedSections > sections {
@@ -435,7 +437,9 @@ func (c *ChainIndexer) setSectionHead(section uint64, hash common.Hash) {
 	var data [8]byte
 	binary.BigEndian.PutUint64(data[:], section)
 
-	c.indexDb.Put(append([]byte("shead"), data[:]...), hash.Bytes())
+	if err := c.indexDb.Put(append([]byte("shead"), data[:]...), hash.Bytes()); err != nil {
+		log.Error("Cannot set chain indexer section head", "section", section, "err", err)
+	}
 }
 
 // removeSectionHead removes the reference to a processed section from the index
@@ -444,5 +448,7 @@ func (c *ChainIndexer) removeSectionHead(section uint64) {
 	var data [8]byte
 	binary.BigEndian.PutUint64(data[:], section)
 
-	c.indexDb.Delete(append([]byte("shead"), data[:]...))
+	if err := c.indexDb.Delete(append([]byte("shead"), data[:]...)); err != nil {
+		log.Error("Cannot remove chain indexer section head", "section", section, "err", err)
+	}
 }

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -261,8 +261,12 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 	if g.Difficulty == nil {
 		head.Difficulty = params.GenesisDifficulty
 	}
-	statedb.Commit(false)
-	statedb.Database().TrieDB().Commit(root, true)
+	if _, err := statedb.Commit(false); err != nil {
+		log.Error("Cannot commit genesis to state db", "err", err)
+	}
+	if err := statedb.Database().TrieDB().Commit(root, true); err != nil {
+		log.Error("Cannot commit genesis to trie db", "err", err)
+	}
 
 	return types.NewBlock(head, nil, nil, nil)
 }

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -169,7 +169,9 @@ func (hc *HeaderChain) WriteHeader(header *types.Header) (status WriteStatus, er
 			headHeader = hc.GetHeader(headHash, headNumber)
 		)
 		for GetCanonicalHash(hc.chainDb, headNumber) != headHash {
-			WriteCanonicalHash(hc.chainDb, headHash, headNumber)
+			if err := WriteCanonicalHash(hc.chainDb, headHash, headNumber); err != nil {
+				log.Error("Cannot write canonical hash", "hash", headHash, "number", headNumber)
+			}
 
 			headHash = headHeader.ParentHash
 			headNumber = headHeader.Number.Uint64() - 1

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gochain-io/gochain/core/types"
 	"github.com/gochain-io/gochain/core/vm"
 	"github.com/gochain-io/gochain/crypto"
+	"github.com/gochain-io/gochain/log"
 	"github.com/gochain-io/gochain/params"
 )
 
@@ -69,7 +70,9 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 		go func() {
 			for i := atomic.AddInt32(&wi, 1); i < l32; i = atomic.AddInt32(&wi, 1) {
 				txs[i].Hash()
-				types.Sender(ctx, signer, txs[i])
+				if _, err := types.Sender(ctx, signer, txs[i]); err != nil {
+					log.Error("Cannot derive address from signature")
+				}
 			}
 		}()
 	}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gochain-io/gochain/eth/gasprice"
 	"github.com/gochain-io/gochain/ethdb"
 	"github.com/gochain-io/gochain/event"
+	"github.com/gochain-io/gochain/log"
 	"github.com/gochain-io/gochain/params"
 	"github.com/gochain-io/gochain/rpc"
 )
@@ -52,7 +53,9 @@ func (b *EthApiBackend) CurrentBlock() *types.Block {
 
 func (b *EthApiBackend) SetHead(number uint64) {
 	b.eth.protocolManager.downloader.Cancel()
-	b.eth.blockchain.SetHead(number)
+	if err := b.eth.blockchain.SetHead(number); err != nil {
+		log.Error("Cannot set eth api backend head", "number", number, "err", err)
+	}
 }
 
 func (b *EthApiBackend) HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Header, error) {

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -321,7 +321,9 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 			// Stream completed traces to the user, aborting on the first error
 			for result, ok := done[next]; ok; result, ok = done[next] {
 				if len(result.Traces) > 0 || next == end.NumberU64() {
-					notifier.Notify(sub.ID, result)
+					if err := notifier.Notify(sub.ID, result); err != nil {
+						log.Error("Debug api cannot notify", "id", sub.ID, "err", err)
+					}
 				}
 				delete(done, next)
 				next++

--- a/eth/bloombits.go
+++ b/eth/bloombits.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gochain-io/gochain/core/bloombits"
 	"github.com/gochain-io/gochain/core/types"
 	"github.com/gochain-io/gochain/ethdb"
+	"github.com/gochain-io/gochain/log"
 	"github.com/gochain-io/gochain/params"
 )
 
@@ -123,7 +124,9 @@ func (b *BloomIndexer) Reset(section uint64, lastSectionHead common.Hash) error 
 // Process implements core.ChainIndexerBackend, adding a new header's bloom into
 // the index.
 func (b *BloomIndexer) Process(header *types.Header) {
-	b.gen.AddBloom(uint(header.Number.Uint64()-b.section*b.size), header.Bloom)
+	if err := b.gen.AddBloom(uint(header.Number.Uint64()-b.section*b.size), header.Bloom); err != nil {
+		log.Error("Cannot add bloom to indexer")
+	}
 	b.head = header.Hash()
 }
 

--- a/eth/db_upgrade.go
+++ b/eth/db_upgrade.go
@@ -41,7 +41,9 @@ func upgradeDeduplicateData(db ethdb.Database) func() error {
 		return nil
 	}
 	if data, _ := db.Get([]byte("LastHeader")); len(data) == 0 {
-		db.Put(deduplicateData, []byte{42})
+		if err := db.Put(deduplicateData, []byte{42}); err != nil {
+			log.Error("Cannot update deduplicate data key", "err", err)
+		}
 		return nil
 	}
 	// Start the deduplication upgrade on a new goroutine
@@ -116,7 +118,9 @@ func upgradeDeduplicateData(db ethdb.Database) func() error {
 		// Upgrade finished, mark a such and terminate
 		if failed == nil {
 			log.Info("Database deduplication successful", "deduped", converted)
-			db.Put(deduplicateData, []byte{42})
+			if err := db.Put(deduplicateData, []byte{42}); err != nil {
+				log.Error("Cannot update deduplicate data key on success", "err", err)
+			}
 		} else {
 			log.Error("Database deduplication failed", "deduped", converted, "err", failed)
 		}

--- a/les/fetcher.go
+++ b/les/fetcher.go
@@ -482,7 +482,11 @@ func (f *lightFetcher) nextRequest() (*distReq, uint64) {
 					time.Sleep(hardRequestTimeout)
 					f.timeoutChn <- reqID
 				}()
-				return func() { p.RequestHeadersByHash(reqID, cost, bestHash, int(bestAmount), 0, true) }
+				return func() {
+					if err := p.RequestHeadersByHash(reqID, cost, bestHash, int(bestAmount), 0, true); err != nil {
+						log.Error("Cannot request headers by hash", "req_id", reqID, "err", err)
+					}
+				}
 			},
 		}
 	}

--- a/les/odr.go
+++ b/les/odr.go
@@ -104,7 +104,11 @@ func (odr *LesOdr) Retrieve(ctx context.Context, req light.OdrRequest) (err erro
 			p := dp.(*peer)
 			cost := lreq.GetCost(p)
 			p.fcServer.QueueRequest(reqID, cost)
-			return func() { lreq.Request(reqID, p) }
+			return func() {
+				if err := lreq.Request(reqID, p); err != nil {
+					log.Error("Cannot request (les odr)", "req_id", reqID, "err", err)
+				}
+			}
 		},
 	}
 

--- a/les/retrieve.go
+++ b/les/retrieve.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/gochain-io/gochain/common/mclock"
+	"github.com/gochain-io/gochain/log"
 )
 
 var (
@@ -319,7 +320,9 @@ func (r *sentReq) tryRequest() {
 		if hrto {
 			pp.Log().Debug("Request timed out hard")
 			if r.rm.peers != nil {
-				r.rm.peers.Unregister(pp.id)
+				if err := r.rm.peers.Unregister(pp.id); err != nil {
+					log.Error("Cannot unregister peer after request attempt", "id", pp.id, "err", err)
+				}
 			}
 		}
 

--- a/les/server.go
+++ b/les/server.go
@@ -132,7 +132,9 @@ func (s *LesServer) SetBloomBitsIndexer(bloomIndexer *core.ChainIndexer) {
 
 // Stop stops the LES service
 func (s *LesServer) Stop() {
-	s.chtIndexer.Close()
+	if err := s.chtIndexer.Close(); err != nil {
+		log.Error("Cannot close les chain indexer", "err", err)
+	}
 	// bloom trie indexer is closed by parent bloombits indexer
 	s.fcCostStats.store()
 	s.fcManager.Stop()
@@ -276,7 +278,9 @@ func (s *requestCostStats) store() {
 	}
 
 	if data, err := rlp.EncodeToBytes(statsRlp); err == nil {
-		s.db.Put(rcStatsKey, data)
+		if err := s.db.Put(rcStatsKey, data); err != nil {
+			log.Error("Cannot put les req cost stats", "err", err)
+		}
 	}
 }
 

--- a/les/serverpool.go
+++ b/les/serverpool.go
@@ -412,8 +412,12 @@ func (pool *serverPool) saveNodes() {
 		list[i] = pool.knownQueue.fetchOldest()
 	}
 	enc, err := rlp.EncodeToBytes(list)
-	if err == nil {
-		pool.db.Put(pool.dbKey, enc)
+	if err != nil {
+		log.Error("Cannot encode server pool known queue", "err", err)
+		return
+	}
+	if err := pool.db.Put(pool.dbKey, enc); err != nil {
+		log.Error("Cannot put server pool known queue", "err", err)
 	}
 }
 

--- a/les/sync.go
+++ b/les/sync.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gochain-io/gochain/core"
 	"github.com/gochain-io/gochain/eth/downloader"
 	"github.com/gochain-io/gochain/light"
+	"github.com/gochain-io/gochain/log"
 )
 
 const (
@@ -80,5 +81,7 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 	pm.blockchain.(*light.LightChain).SyncCht(ctx)
-	pm.downloader.Synchronise(ctx, peer.id, peer.Head(), peer.Td(), downloader.LightSync)
+	if err := pm.downloader.Synchronise(ctx, peer.id, peer.Head(), peer.Td(), downloader.LightSync); err != nil {
+		log.Error("Cannot synchronise downloader", "id", peer.id, "head", peer.Head(), "err", err)
+	}
 }

--- a/les/txrelay.go
+++ b/les/txrelay.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gochain-io/gochain/common"
 	"github.com/gochain-io/gochain/core/types"
+	"github.com/gochain-io/gochain/log"
 )
 
 type ltrInfo struct {
@@ -127,7 +128,11 @@ func (self *LesTxRelay) send(txs types.Transactions, count int) {
 				peer := dp.(*peer)
 				cost := peer.GetRequestCost(SendTxMsg, len(ll))
 				peer.fcServer.QueueRequest(reqID, cost)
-				return func() { peer.SendTxs(reqID, cost, ll) }
+				return func() {
+					if err := peer.SendTxs(reqID, cost, ll); err != nil {
+						log.Error("Cannot send txs in relay", "req_id", reqID, "err", err)
+					}
+				}
 			},
 		}
 		self.reqDist.queue(rq)

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -166,7 +166,9 @@ func (bc *LightChain) SetHead(head uint64) {
 	defer bc.mu.Unlock()
 
 	bc.hc.SetHead(head, nil)
-	bc.loadLastState()
+	if err := bc.loadLastState(); err != nil {
+		log.Error("Cannot load last state while setting head", "err", err)
+	}
 }
 
 // GasLimit returns the gas limit of the current HEAD block.

--- a/light/nodeset.go
+++ b/light/nodeset.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gochain-io/gochain/common"
 	"github.com/gochain-io/gochain/crypto"
 	"github.com/gochain-io/gochain/ethdb"
+	"github.com/gochain-io/gochain/log"
 	"github.com/gochain-io/gochain/rlp"
 )
 
@@ -111,7 +112,9 @@ func (db *NodeSet) Store(target ethdb.Putter) {
 	defer db.lock.RUnlock()
 
 	for key, value := range db.nodes {
-		target.Put([]byte(key), value)
+		if err := target.Put([]byte(key), value); err != nil {
+			log.Error("Cannot write node set", "err", err)
+		}
 	}
 }
 
@@ -121,7 +124,9 @@ type NodeList []rlp.RawValue
 // Store writes the contents of the list to the given database
 func (n NodeList) Store(db ethdb.Putter) {
 	for _, node := range n {
-		db.Put(crypto.Keccak256(node), node)
+		if err := db.Put(crypto.Keccak256(node), node); err != nil {
+			log.Error("Cannot write node list", "err", err)
+		}
 	}
 }
 

--- a/light/postprocess.go
+++ b/light/postprocess.go
@@ -113,7 +113,9 @@ func GetChtV2Root(db ethdb.Database, sectionIdx uint64, sectionHead common.Hash)
 func StoreChtRoot(db ethdb.Database, sectionIdx uint64, sectionHead, root common.Hash) {
 	var encNumber [8]byte
 	binary.BigEndian.PutUint64(encNumber[:], sectionIdx)
-	db.Put(append(append(chtPrefix, encNumber[:]...), sectionHead.Bytes()...), root.Bytes())
+	if err := db.Put(append(append(chtPrefix, encNumber[:]...), sectionHead.Bytes()...), root.Bytes()); err != nil {
+		log.Error("Cannot store cht root", "err", err)
+	}
 }
 
 // ChtIndexerBackend implements core.ChainIndexerBackend
@@ -177,7 +179,9 @@ func (c *ChtIndexerBackend) Commit() error {
 	if err != nil {
 		return err
 	}
-	c.triedb.Commit(root, false)
+	if err := c.triedb.Commit(root, false); err != nil {
+		log.Error("Cannot commit cht indexer backend", "err", err)
+	}
 
 	if ((c.section+1)*c.sectionSize)%CHTFrequencyClient == 0 {
 		log.Info("Storing CHT", "section", c.section*c.sectionSize/CHTFrequencyClient, "head", c.lastHash, "root", root)
@@ -209,7 +213,9 @@ func GetBloomTrieRoot(db ethdb.Database, sectionIdx uint64, sectionHead common.H
 func StoreBloomTrieRoot(db ethdb.Database, sectionIdx uint64, sectionHead, root common.Hash) {
 	var encNumber [8]byte
 	binary.BigEndian.PutUint64(encNumber[:], sectionIdx)
-	db.Put(append(append(bloomTriePrefix, encNumber[:]...), sectionHead.Bytes()...), root.Bytes())
+	if err := db.Put(append(append(bloomTriePrefix, encNumber[:]...), sectionHead.Bytes()...), root.Bytes()); err != nil {
+		log.Error("Cannot store bloom trie root", "err", err)
+	}
 }
 
 // BloomTrieIndexerBackend implements core.ChainIndexerBackend
@@ -296,7 +302,9 @@ func (b *BloomTrieIndexerBackend) Commit() error {
 	if err != nil {
 		return err
 	}
-	b.triedb.Commit(root, false)
+	if err := b.triedb.Commit(root, false); err != nil {
+		log.Error("Cannot store bloom trie indexer trie db", "err", err)
+	}
 
 	sectionHead := b.sectionHeads[b.bloomTrieRatio-1]
 	log.Info("Storing bloom trie", "section", b.section, "head", sectionHead, "root", root, "compression", float64(compSize)/float64(decompSize))

--- a/node/api.go
+++ b/node/api.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gochain-io/gochain/common/hexutil"
 	"github.com/gochain-io/gochain/crypto"
+	"github.com/gochain-io/gochain/log"
 	"github.com/gochain-io/gochain/p2p"
 	"github.com/gochain-io/gochain/p2p/discover"
 	"github.com/gochain-io/gochain/rpc"
@@ -99,7 +100,9 @@ func (api *PrivateAdminAPI) PeerEvents(ctx context.Context) (*rpc.Subscription, 
 		for {
 			select {
 			case event := <-events:
-				notifier.Notify(rpcSub.ID, event)
+				if err := notifier.Notify(rpcSub.ID, event); err != nil {
+					log.Error("Cannot notify peer event", "id", rpcSub.ID)
+				}
 			case <-sub.Err():
 				return
 			case <-rpcSub.Err():

--- a/node/node.go
+++ b/node/node.go
@@ -203,7 +203,9 @@ func (n *Node) Start(ctx context.Context) error {
 		// Start the next service, stopping all previous upon failure
 		if err := service.Start(ctx, running); err != nil {
 			for _, kind := range started {
-				services[kind].Stop()
+				if err := services[kind].Stop(); err != nil {
+					log.Error("Cannot stop node service", "err", err)
+				}
 			}
 			running.Stop()
 
@@ -215,7 +217,9 @@ func (n *Node) Start(ctx context.Context) error {
 	// Lastly start the configured RPC interfaces
 	if err := n.startRPC(services); err != nil {
 		for _, service := range services {
-			service.Stop()
+			if err := service.Stop(); err != nil {
+				log.Error("Cannot stop node service", "err", err)
+			}
 		}
 		running.Stop()
 		return err
@@ -354,7 +358,9 @@ func (n *Node) startIPC(apis []rpc.API) error {
 // stopIPC terminates the IPC RPC endpoint.
 func (n *Node) stopIPC() {
 	if n.ipcListener != nil {
-		n.ipcListener.Close()
+		if err := n.ipcListener.Close(); err != nil {
+			log.Error("Cannot stop ipc listener", "err", err)
+		}
 		n.ipcListener = nil
 
 		n.log.Info("IPC endpoint closed", "endpoint", n.ipcEndpoint)
@@ -407,7 +413,9 @@ func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors
 // stopHTTP terminates the HTTP RPC endpoint.
 func (n *Node) stopHTTP() {
 	if n.httpListener != nil {
-		n.httpListener.Close()
+		if err := n.httpListener.Close(); err != nil {
+			log.Error("Cannot stop node http listener", "err", err)
+		}
 		n.httpListener = nil
 
 		n.log.Info("HTTP endpoint closed", "url", fmt.Sprintf("http://%s", n.httpEndpoint))
@@ -461,7 +469,9 @@ func (n *Node) startWS(endpoint string, apis []rpc.API, modules []string, wsOrig
 // stopWS terminates the websocket RPC endpoint.
 func (n *Node) stopWS() {
 	if n.wsListener != nil {
-		n.wsListener.Close()
+		if err := n.wsListener.Close(); err != nil {
+			log.Error("Cannot stop node ws listener", "err", err)
+		}
 		n.wsListener = nil
 
 		n.log.Info("WebSocket endpoint closed", "url", fmt.Sprintf("ws://%s", n.wsEndpoint))

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -300,7 +300,9 @@ func (t *dialTask) Do(srv *Server) {
 		// Try resolving the ID of static nodes if dialing failed.
 		if _, ok := err.(*dialError); ok && t.flags&staticDialedConn != 0 {
 			if t.resolve(srv) {
-				t.dial(srv, t.dest)
+				if err := t.dial(srv, t.dest); err != nil {
+					log.Error("Cannot dial static node", "err", err)
+				}
 			}
 		}
 	}

--- a/rpc/ipc_unix.go
+++ b/rpc/ipc_unix.go
@@ -23,6 +23,8 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+
+	"github.com/gochain-io/gochain/log"
 )
 
 // ipcListen will create a Unix socket on the given endpoint.
@@ -31,12 +33,16 @@ func ipcListen(endpoint string) (net.Listener, error) {
 	if err := os.MkdirAll(filepath.Dir(endpoint), 0751); err != nil {
 		return nil, err
 	}
-	os.Remove(endpoint)
+	if err := os.Remove(endpoint); err != nil && !os.IsNotExist(err) {
+		log.Error("Cannot remove ipc endpoint", "err", err)
+	}
 	l, err := net.Listen("unix", endpoint)
 	if err != nil {
 		return nil, err
 	}
-	os.Chmod(endpoint, 0600)
+	if err := os.Chmod(endpoint, 0600); err != nil {
+		log.Error("Cannot chmod ipc endpoint", "err", err)
+	}
 	return l, nil
 }
 

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -345,7 +345,9 @@ func (c *jsonCodec) Write(res interface{}) error {
 func (c *jsonCodec) Close() {
 	c.closer.Do(func() {
 		close(c.closed)
-		c.rw.Close()
+		if err := c.rw.Close(); err != nil {
+			log.Error("Cannot close json codec rw", "err", err)
+		}
 	})
 }
 

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -134,7 +134,9 @@ func wsDialContext(ctx context.Context, config *websocket.Config) (*websocket.Co
 	}
 	ws, err := websocket.NewClient(config, conn)
 	if err != nil {
-		conn.Close()
+		if e := conn.Close(); e != nil {
+			log.Error("Cannot close websocket connection on error", "err", err)
+		}
 		return nil, err
 	}
 	return ws, err

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -81,7 +81,9 @@ func (t *Trie) Prove(key []byte, fromLevel uint, proofDb ethdb.Putter) error {
 				if !ok {
 					hash = crypto.Keccak256(enc)
 				}
-				proofDb.Put(hash, enc)
+				if err := proofDb.Put(hash, enc); err != nil {
+					log.Error("Cannot insert into proof db", "err", err)
+				}
 			}
 		}
 	}

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gochain-io/gochain/common"
 	"github.com/gochain-io/gochain/ethdb"
+	"github.com/gochain-io/gochain/log"
 	"gopkg.in/karalabe/cookiejar.v2/collections/prque"
 )
 
@@ -182,7 +183,9 @@ func (s *TrieSync) Process(results []SyncResult) (bool, int, error) {
 		// If the item is a raw entry request, commit directly
 		if request.raw {
 			request.data = item.Data
-			s.commit(request)
+			if err := s.commit(request); err != nil {
+				log.Error("Cannot raw commit trie sync", "err", err)
+			}
 			committed = true
 			continue
 		}
@@ -199,7 +202,9 @@ func (s *TrieSync) Process(results []SyncResult) (bool, int, error) {
 			return committed, i, err
 		}
 		if len(requests) == 0 && request.deps == 0 {
-			s.commit(request)
+			if err := s.commit(request); err != nil {
+				log.Error("Cannot commit trie sync", "err", err)
+			}
 			committed = true
 			continue
 		}


### PR DESCRIPTION
This commit adds error propagation or logging for all errors that can return an error and where the errors are important. One type of error that is ignored is writing to `hash.Hash` or reading from `crypto/rand.Read()` which cannot fail. Another type of error that is ignored is closing of read-only files.