### PR TITLE
core/state, eth, internal/ethapi, miner: query state instead of copying

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math/big"
 	"sort"
-	"sync"
 
 	"github.com/gochain-io/gochain/common"
 	"github.com/gochain-io/gochain/core/types"
@@ -72,8 +71,6 @@ type StateDB struct {
 	journal        journal
 	validRevisions []revision
 	nextRevisionId int
-
-	lock sync.Mutex
 }
 
 // Create a new state from a given trie
@@ -479,9 +476,6 @@ func (db *StateDB) ForEachStorage(addr common.Address, cb func(key, value common
 // Copy creates a deep, independent copy of the state.
 // Snapshots of the copied state cannot be applied to the copy.
 func (db *StateDB) Copy() *StateDB {
-	db.lock.Lock()
-	defer db.lock.Unlock()
-
 	// Copy all the basic fields, initialize the memory ones
 	state := &StateDB{
 		db:                db.db,

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -81,6 +81,22 @@ func (b *EthApiBackend) BlockByNumber(ctx context.Context, blockNr rpc.BlockNumb
 	return b.eth.blockchain.GetBlockByNumber(uint64(blockNr)), nil
 }
 
+func (b *EthApiBackend) StateQuery(ctx context.Context, blockNr rpc.BlockNumber, fn func(*state.StateDB) error) error {
+	// Pending state is only known by the miner
+	if blockNr == rpc.PendingBlockNumber {
+		return b.eth.miner.PendingQuery(fn)
+	}
+	header, err := b.HeaderByNumber(ctx, blockNr)
+	if header == nil || err != nil {
+		return err
+	}
+	stateDb, err := b.eth.BlockChain().StateAt(header.Root)
+	if err != nil {
+		return err
+	}
+	return fn(stateDb)
+}
+
 func (b *EthApiBackend) StateAndHeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*state.StateDB, *types.Header, error) {
 	// Pending state is only known by the miner
 	if blockNr == rpc.PendingBlockNumber {

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -49,8 +49,9 @@ type Backend interface {
 	SetHead(number uint64)
 	HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Header, error)
 	BlockByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Block, error)
-	// StateAndHeaderByNumber returns a read-only state.StateDB, which must be copied via Copy() before modifying.
 	StateAndHeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*state.StateDB, *types.Header, error)
+	// StateQuery calls fn with a read-only state.StateDB.
+	StateQuery(ctx context.Context, blockNr rpc.BlockNumber, fn func(db *state.StateDB) error) error
 	GetBlock(ctx context.Context, blockHash common.Hash) (*types.Block, error)
 	GetReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error)
 	GetTd(blockHash common.Hash) *big.Int

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -71,6 +71,14 @@ func (b *LesApiBackend) BlockByNumber(ctx context.Context, blockNr rpc.BlockNumb
 	return b.GetBlock(ctx, header.Hash())
 }
 
+func (b *LesApiBackend) StateQuery(ctx context.Context, blockNr rpc.BlockNumber, fn func(*state.StateDB) error) error {
+	header, err := b.HeaderByNumber(ctx, blockNr)
+	if header == nil || err != nil {
+		return err
+	}
+	return fn(light.NewState(ctx, header, b.eth.odr))
+}
+
 func (b *LesApiBackend) StateAndHeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*state.StateDB, *types.Header, error) {
 	header, err := b.HeaderByNumber(ctx, blockNr)
 	if header == nil || err != nil {

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -170,6 +170,11 @@ func (self *Miner) Pending() (*types.Block, *state.StateDB) {
 	return self.worker.pending()
 }
 
+// PendingQuery calls fn with the pending (ready-only) state.
+func (self *Miner) PendingQuery(fn func(*state.StateDB) error) error {
+	return self.worker.pendingQuery(fn)
+}
+
 // PendingBlock returns the currently pending block.
 //
 // Note, to access both the pending block and the pending state


### PR DESCRIPTION
This PR aims to fix a map write/iter race and optimize some pending state queries. Instead of locking to copy the state, then querying on the copy, we can just query the state while locked, since these are simple read-only queries anyways (and should be cheaper/faster than copying the whole state). This also reverts/replaces a change from #136, which was racy, since _logical_ reads can still write to internal state (e.g. caches). The new read queries hold locks to avoid this.