### PR TITLE
circle ci: switch to workflow; use docker image; add caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,82 @@
-version: 2
+version: 2.0
+
+defaults: &defaults
+  working_directory: /go/src/github.com/gochain-io/gochain
+  docker:
+    - image: circleci/golang:1.10.2
+  environment: # apparently expansion doesn't work here yet: https://discuss.circleci.com/t/environment-variable-expansion-in-working-directory/11322
+    - OS=linux
+    - ARCH=amd64
+    - GOCACHE=/tmp/go/cache
+
 jobs:
+  prepare:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: install dependencies
+          command: |
+            go get -u github.com/golang/dep/cmd/dep
+            dep ensure --vendor-only
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+
   build:
+    <<: *defaults
+    steps:
+      - restore_cache:
+          keys:
+              - build-cache-{{ .Branch }}-{{ .Environment.CIRCLE_PREVIOUS_BUILD_NUM }}
+              - build-cache-{{ .Branch }}-
+              - build-cache-
+          paths:
+              - /tmp/go/cache
+      - attach_workspace:
+          at: .
+      - run: make all
+      - save_cache:
+          key: build-cache-{{ .Branch }}-{{ .Environment.CIRCLE_BUILD_NUM }}
+          paths:
+              - /tmp/go/cache
+
+  test:
+    <<: *defaults
+    steps:
+      - restore_cache:
+          keys:
+              - test-cache-{{ .Branch }}-{{ .Environment.CIRCLE_PREVIOUS_BUILD_NUM }}
+              - test-cache-{{ .Branch }}-
+              - test-cache-
+          paths:
+              - /tmp/go/cache
+      - attach_workspace:
+          at: .
+      - run: go test $(go list ./... | grep -v /swarm/fuse)
+      - save_cache:
+          key: test-cache-{{ .Branch }}-{{ .Environment.CIRCLE_BUILD_NUM }}
+          paths:
+              - /tmp/go/cache
+
+  # Separate since fuse is not supported via containers.
+  test-fuse:
     machine: true
     working_directory: ~/go/src/github.com/gochain-io/gochain
     environment: # apparently expansion doesn't work here yet: https://discuss.circleci.com/t/environment-variable-expansion-in-working-directory/11322
       - GOPATH=/home/circleci/go
-      - GOVERSION=1.10
+      - GOVERSION=1.10.2
       - OS=linux
       - ARCH=amd64
     steps:
+      - restore_cache:
+          keys:
+              - test-fuse-cache-{{ .Branch }}-{{ .Environment.CIRCLE_PREVIOUS_BUILD_NUM }}
+              - test-fuse-cache-{{ .Branch }}-
+              - test-fuse-cache-
+          paths:
+              - /tmp/go/cache
       - checkout
       - run:
           name: update Go
@@ -22,20 +90,41 @@ jobs:
             sudo tar -C /usr/local -xzf go$GOVERSION.$OS-$ARCH.tar.gz
             export PATH=$PATH:$HOME/go/bin
       - run: go version
-      - run: 
-          name: update Docker
-          command: |
-            docker version
-            sudo service docker stop
-            curl -fsSL https://get.docker.com/ | sudo sh
-      - run: docker version
       - run:
           name: install dependencies
           command: |
             go get -u github.com/golang/dep/cmd/dep
             ${GOPATH}/bin/dep ensure --vendor-only
       - run: make all
-      - run: make test
+      - run: go test ./swarm/fuse
+      - save_cache:
+          key: test-fuse-cache-{{ .Branch }}-{{ .Environment.CIRCLE_BUILD_NUM }}
+          paths:
+              - /tmp/go/cache
+
+  race:
+    <<: *defaults
+    steps:
+      - restore_cache:
+          keys:
+              - race-cache-{{ .Branch }}-{{ .Environment.CIRCLE_PREVIOUS_BUILD_NUM }}
+              - race-cache-{{ .Branch }}-
+              - race-cache-
+          paths:
+              - /tmp/go/cache
+      - attach_workspace:
+          at: .
+      - run: go test -race ./core/...
+      - save_cache:
+          key: race-cache-{{ .Branch }}-{{ .Environment.CIRCLE_BUILD_NUM }}
+          paths:
+              - /tmp/go/cache
+
+  release-master:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
       - deploy:
           command: |
             if [[ "${CIRCLE_BRANCH}" == "master" && -z "${CIRCLE_PR_REPONAME}" ]]; then
@@ -45,6 +134,12 @@ jobs:
               git branch --set-upstream-to=origin/${CIRCLE_BRANCH} ${CIRCLE_BRANCH}
               ./release.sh
             fi
+
+  push-testnet:
+    <<: *defaults
+    steps:
+      - deploy:
+          command: |
             if [[ "${CIRCLE_BRANCH}" == "testnet" && -z "${CIRCLE_PR_REPONAME}" ]]; then
               echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
               version_file="params/version.go"
@@ -54,12 +149,72 @@ jobs:
               docker tag gochain/gochain:${version} gochain/gochain:testnet
               docker push gochain/gochain:testnet
             fi
-            if [[ "${CIRCLE_BRANCH}" == "mainnet" && -z "${CIRCLE_PR_REPONAME}" ]]; then
+
+  push-stable:
+    <<: *defaults
+    steps:
+      - deploy:
+          command: |
+            if [[ "${CIRCLE_BRANCH}" == "stable" && -z "${CIRCLE_PR_REPONAME}" ]]; then
               echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
               version_file="params/version.go"
               version=$(grep -m1 -Eo "[0-9]+\.[0-9]+\.[0-9]+" ${version_file})
               echo "Version: ${version}"
               docker pull gochain/gochain:${version}
-              docker tag gochain/gochain:${version} gochain/gochain:mainnet
-              docker push gochain/gochain:mainnet
+              docker tag gochain/gochain:${version} gochain/gochain:stable
+              docker push gochain/gochain:stable
             fi
+
+workflows:
+  version: 2
+  prepare-accept-deploy:
+    jobs:
+      - prepare
+      - build:
+          requires:
+            - prepare
+
+      - test:
+          requires:
+            - prepare
+      - test-fuse:
+          requires:
+            - prepare
+      - race:
+          requires:
+            - prepare
+
+      - release-master:
+          filters:
+            branches:
+              only: master
+          requires:
+            - build
+            - test
+            - test-fuse
+            - race
+      - push-testnet:
+          filters:
+            branches:
+              only: testnet
+          requires:
+            - build
+            - test
+            - test-fuse
+            - race
+      - approve-push-stable:
+          type: approval
+          filters:
+            branches:
+              only: stable
+          requires:
+            - build
+            - test
+            - test-fuse
+            - race
+      - push-stable:
+          filters:
+            branches:
+              only: stable
+          requires:
+            - approve-push-stable


### PR DESCRIPTION
By using a `workflow`, a custom docker image, and caching, we can speed up circleci builds. We're also set up to benefit from parallelism in the future. Builds were usually ~15m, but as short as 10m or as long as 20m, and frequently timed out. Now we are broken into pieces which shouldn't time out individually, and total runtime is around ~10m, with caching as quick as 4m. For some reason, tests run much faster in this circleci container image than in the previous mode, so even with the redundant, old-style fuse step wasting 2 minutes, and a new step running `-race` against `core` for ~3m, the overall time is still faster. The workflow screen provides a nice visual of the individual builds:
![screenshot from 2018-05-09 06-59-19](https://user-images.githubusercontent.com/1194128/39813555-8530291a-5356-11e8-8646-bfa932b4de06.png)
These individual build jobs can be restarted independently as well, so we won't lose so much time from doing complete rebuilds after random test failures.

Towards #164 