### PR TITLE
all: revert and re-implement vm.StateDB defaults and error handling

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gochain-io/gochain/core/types"
 	"github.com/gochain-io/gochain/core/vm"
 	"github.com/gochain-io/gochain/ethdb"
-	"github.com/gochain-io/gochain/log"
 	"github.com/gochain-io/gochain/params"
 )
 
@@ -119,11 +118,7 @@ func (b *BlockGen) TxNonce(addr common.Address) uint64 {
 	if !b.statedb.Exist(addr) {
 		panic("account does not exist")
 	}
-	nonce, err := b.statedb.GetNonce(addr)
-	if err != nil {
-		log.Error("Failed to get nonce", "err", err)
-	}
-	return nonce
+	return b.statedb.GetNonce(addr)
 }
 
 // AddUncle adds an uncle header to the generated block.

--- a/core/chain_makers_test.go
+++ b/core/chain_makers_test.go
@@ -91,12 +91,9 @@ func ExampleGenerateChain() {
 
 	state, _ := blockchain.State()
 	fmt.Printf("last block: #%d\n", blockchain.CurrentBlock().Number())
-	bal, _ := state.GetBalance(addr1)
-	fmt.Println("balance of addr1:", bal)
-	bal, _ = state.GetBalance(addr2)
-	fmt.Println("balance of addr2:", bal)
-	bal, _ = state.GetBalance(addr3)
-	fmt.Println("balance of addr3:", bal)
+	fmt.Println("balance of addr1:", state.GetBalance(addr1))
+	fmt.Println("balance of addr2:", state.GetBalance(addr2))
+	fmt.Println("balance of addr3:", state.GetBalance(addr3))
 	// Output:
 	// last block: #5
 	// balance of addr1: 989000

--- a/core/evm.go
+++ b/core/evm.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gochain-io/gochain/consensus"
 	"github.com/gochain-io/gochain/core/types"
 	"github.com/gochain-io/gochain/core/vm"
-	"github.com/gochain-io/gochain/log"
 )
 
 // ChainContext supports retrieving headers and consensus parameters from the
@@ -96,11 +95,7 @@ func GetHashFn(ref *types.Header, chain ChainContext) func(n uint64) common.Hash
 // CanTransfer checks wether there are enough funds in the address' account to make a transfer.
 // This does not take the necessary gas in to account to make the transfer valid.
 func CanTransfer(db vm.StateDB, addr common.Address, amount *big.Int) bool {
-	bal, err := db.GetBalance(addr)
-	if err != nil {
-		log.Error("Failed to get balance", "err", err)
-	}
-	return bal.Cmp(amount) >= 0
+	return db.GetBalance(addr).Cmp(amount) >= 0
 }
 
 // Transfer subtracts amount from sender and adds amount to recipient using the given Db

--- a/core/state/managed_state.go
+++ b/core/state/managed_state.go
@@ -86,13 +86,13 @@ func (ms *ManagedState) NewNonce(addr common.Address) uint64 {
 // GetNonce returns the canonical nonce for the managed or unmanaged account.
 //
 // Because GetNonce mutates the DB, we must take a write lock.
-func (ms *ManagedState) GetNonce(addr common.Address) (uint64, error) {
+func (ms *ManagedState) GetNonce(addr common.Address) uint64 {
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
 
 	if ms.hasAccount(addr) {
 		account := ms.getAccount(addr)
-		return uint64(len(account.nonces)) + account.nstart, nil
+		return uint64(len(account.nonces)) + account.nstart
 	} else {
 		return ms.StateDB.GetNonce(addr)
 	}

--- a/core/state/managed_state_test.go
+++ b/core/state/managed_state_test.go
@@ -115,18 +115,14 @@ func TestSetNonce(t *testing.T) {
 	var addr common.Address
 	ms.SetNonce(addr, 10)
 
-	if nonce, err := ms.GetNonce(addr); err != nil {
-		t.Fatal(err)
-	} else if nonce != 10 {
+	if nonce := ms.GetNonce(addr); nonce != 10 {
 		t.Error("Expected nonce of 10, got", nonce)
 	}
 
 	addr[0] = 1
 	ms.StateDB.SetNonce(addr, 1)
 
-	if nonce, err := ms.GetNonce(addr); err != nil {
-		t.Fatal(err)
-	} else if nonce != 1 {
+	if nonce := ms.GetNonce(addr); nonce != 1 {
 		t.Error("Expected nonce of 1, got", nonce)
 	}
 }

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -98,10 +98,7 @@ func (s *StateSuite) TestNull(c *checker.C) {
 	var value common.Hash
 	s.state.SetState(address, common.Hash{}, value)
 	s.state.Commit(false)
-	value, err := s.state.GetState(address, common.Hash{})
-	if err != nil {
-		c.Fatal(err)
-	}
+	value = s.state.GetState(address, common.Hash{})
 	if !common.EmptyHash(value) {
 		c.Errorf("expected empty hash. got %x", value)
 	}
@@ -124,11 +121,7 @@ func (s *StateSuite) TestSnapshot(c *checker.C) {
 	s.state.RevertToSnapshot(snapshot)
 
 	// get state storage value
-	res, err := s.state.GetState(stateobjaddr, storageaddr)
-	if err != nil {
-		c.Fatal(err)
-	}
-
+	res := s.state.GetState(stateobjaddr, storageaddr)
 	c.Assert(data1, checker.DeepEquals, res)
 }
 

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -376,43 +376,24 @@ func (test *snapshotTest) checkEqual(state, checkstate *StateDB) error {
 		// Check basic accessor methods.
 		checkeq("Exist", state.Exist(addr), checkstate.Exist(addr))
 		checkeq("HasSuicided", state.HasSuicided(addr), checkstate.HasSuicided(addr))
-		sb, err := state.GetBalance(addr)
-		csb, cerr := checkstate.GetBalance(addr)
-		checkeq("GetBalance", sb, csb)
-		checkeq("GetBalanceErr", err, cerr)
-		sn, err := state.GetNonce(addr)
-		csn, cerr := checkstate.GetNonce(addr)
-		checkeq("GetNonce", sn, csn)
-		checkeq("GetNonce", err, cerr)
-		sc, err := state.GetCode(addr)
-		csc, cerr := checkstate.GetCode(addr)
-		checkeq("GetCode", sc, csc)
-		checkeq("GetCodeErr", err, cerr)
-		sch, err := state.GetCodeHash(addr)
-		csch, cerr := checkstate.GetCodeHash(addr)
-		checkeq("GetCodeHash", sch, csch)
-		checkeq("GetCodeHashErr", err, cerr)
-		scs, err := state.GetCodeSize(addr)
-		cscs, cerr := checkstate.GetCodeSize(addr)
-		checkeq("GetCodeSize", scs, cscs)
-		checkeq("GetCodeSizeErr", err, cerr)
+		checkeq("GetBalance", state.GetBalance(addr), checkstate.GetBalance(addr))
+		checkeq("GetNonce", state.GetNonce(addr), checkstate.GetNonce(addr))
+		checkeq("GetCode", state.GetCode(addr), checkstate.GetCode(addr))
+		checkeq("GetCodeHash", state.GetCodeHash(addr), checkstate.GetCodeHash(addr))
+		checkeq("GetCodeSize", state.GetCodeSize(addr), checkstate.GetCodeSize(addr))
 		// Check storage.
 		if obj, err := state.getStateObject(addr); err != nil {
 			return fmt.Errorf("failed to get state: %s", err)
 		} else if obj != nil {
 			var err error
 			state.ForEachStorage(addr, func(key, val common.Hash) bool {
-				var st common.Hash
-				st, err = checkstate.GetState(addr, key)
-				return checkeq("GetState("+key.Hex()+")", val, st)
+				return checkeq("GetState("+key.Hex()+")", val, checkstate.GetState(addr, key))
 			})
 			if err != nil {
 				return fmt.Errorf("failed to get state: %s", err)
 			}
 			checkstate.ForEachStorage(addr, func(key, checkval common.Hash) bool {
-				var st common.Hash
-				st, err = state.GetState(addr, key)
-				return checkeq("GetState("+key.Hex()+")", st, checkval)
+				return checkeq("GetState("+key.Hex()+")", state.GetState(addr, key), checkval)
 			})
 			if err != nil {
 				return fmt.Errorf("failed to get state: %s", err)

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -79,19 +79,13 @@ func checkStateAccounts(t *testing.T, db ethdb.Database, root common.Hash, accou
 		t.Fatalf("inconsistent state trie at %x: %v", root, err)
 	}
 	for i, acc := range accounts {
-		if balance, err := state.GetBalance(acc.address); err != nil {
-			t.Fatal(err)
-		} else if balance.Cmp(acc.balance) != 0 {
+		if balance := state.GetBalance(acc.address); balance.Cmp(acc.balance) != 0 {
 			t.Errorf("account %d: balance mismatch: have %v, want %v", i, balance, acc.balance)
 		}
-		if nonce, err := state.GetNonce(acc.address); err != nil {
-			t.Fatal(err)
-		} else if nonce != acc.nonce {
+		if nonce := state.GetNonce(acc.address); nonce != acc.nonce {
 			t.Errorf("account %d: nonce mismatch: have %v, want %v", i, nonce, acc.nonce)
 		}
-		if code, err := state.GetCode(acc.address); err != nil {
-			t.Fatal(err)
-		} else if !bytes.Equal(code, acc.code) {
+		if code := state.GetCode(acc.address); !bytes.Equal(code, acc.code) {
 			t.Errorf("account %d: code mismatch: have %x, want %x", i, code, acc.code)
 		}
 	}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -685,20 +685,12 @@ func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction, local
 		return ErrUnderpriced
 	}
 	// Ensure the transaction adheres to nonce ordering
-	nonce, err := pool.currentState.GetNonce(from)
-	if err != nil {
-		log.Error("Failed to get nonce", "err", err)
-	}
-	if nonce > tx.Nonce() {
+	if pool.currentState.GetNonce(from) > tx.Nonce() {
 		return ErrNonceTooLow
 	}
 	// Transactor should have enough funds to cover the costs
 	// cost == V + GP * GL
-	bal, err := pool.currentState.GetBalance(from)
-	if err != nil {
-		log.Error("Failed to get balance", "err", err)
-	}
-	if bal.Cmp(tx.Cost()) < 0 {
+	if pool.currentState.GetBalance(from).Cmp(tx.Cost()) < 0 {
 		return ErrInsufficientFunds
 	}
 	intrGas, err := IntrinsicGas(tx.Data(), tx.To() == nil, pool.homestead)
@@ -1012,10 +1004,7 @@ func (pool *TxPool) removeTx(ctx context.Context, hash common.Hash) {
 				}
 			}
 			// Update the account nonce if needed
-			stNonce, err := pool.pendingState.GetNonce(addr)
-			if err != nil {
-				log.Error("Failed to get nonce", "err", err)
-			}
+			stNonce := pool.pendingState.GetNonce(addr)
 			if nonce := tx.Nonce(); stNonce > nonce {
 				pool.pendingState.SetNonce(addr, nonce)
 			}
@@ -1058,10 +1047,6 @@ func (pool *TxPool) promoteExecutable(addr common.Address, queued *txList) {
 	tracing := log.Tracing()
 
 	// Drop all transactions that are deemed too old (low nonce)
-	nonce, err := pool.currentState.GetNonce(addr)
-	if err != nil {
-		log.Error("Failed to get nonce", "err", err)
-	}
 	remove := func(tx *types.Transaction) {
 		delete(pool.all, tx.Hash())
 	}
@@ -1072,13 +1057,9 @@ func (pool *TxPool) promoteExecutable(addr common.Address, queued *txList) {
 			log.Trace("Removed old queued transaction", "hash", hash)
 		}
 	}
-	queued.Forward(nonce, remove)
+	queued.Forward(pool.currentState.GetNonce(addr), remove)
 
 	// Drop all transactions that are too costly (low balance or out of gas)
-	bal, err := pool.currentState.GetBalance(addr)
-	if err != nil {
-		log.Error("Failed to get balance", "err", err)
-	}
 	remove = func(tx *types.Transaction) {
 		delete(pool.all, tx.Hash())
 		queuedNofundsCounter.Inc(1)
@@ -1091,13 +1072,9 @@ func (pool *TxPool) promoteExecutable(addr common.Address, queued *txList) {
 			log.Trace("Removed unpayable queued transaction", "hash", hash)
 		}
 	}
-	queued.Filter(bal, pool.currentMaxGas, remove, func(*types.Transaction) {})
+	queued.Filter(pool.currentState.GetBalance(addr), pool.currentMaxGas, remove, func(*types.Transaction) {})
 
 	// Gather all executable transactions and promote them
-	nonce, err = pool.pendingState.GetNonce(addr)
-	if err != nil {
-		log.Error("Failed to get nonce", "err", err)
-	}
 	promote := func(tx *types.Transaction) {
 		pool.promoteTx(addr, tx.Hash(), tx)
 	}
@@ -1108,7 +1085,7 @@ func (pool *TxPool) promoteExecutable(addr common.Address, queued *txList) {
 			log.Trace("Removed old queued transaction", "hash", hash)
 		}
 	}
-	queued.Ready(nonce, promote)
+	queued.Ready(pool.pendingState.GetNonce(addr), promote)
 
 	// Drop all transactions over the allowed limit
 	if !pool.locals.contains(addr) {
@@ -1242,11 +1219,7 @@ func (pool *TxPool) limitOffenders(offenders []common.Address, tracing bool) (re
 		nonce = math.MaxUint64
 		pending.Cap(pending.Len()-1, remove)
 		// Update the account nonce to the dropped transaction
-		stNonce, err := pool.pendingState.GetNonce(addr)
-		if err != nil {
-			log.Error("Failed to get nonce", "err", err)
-			continue
-		}
+		stNonce := pool.pendingState.GetNonce(addr)
 		if stNonce > nonce {
 			pool.pendingState.SetNonce(addr, nonce)
 		}
@@ -1260,10 +1233,7 @@ func (pool *TxPool) limitOffenders(offenders []common.Address, tracing bool) (re
 func (pool *TxPool) demoteUnexecutables(ctx context.Context) {
 	// Iterate over all accounts and demote any non-executable transactions
 	for addr, pending := range pool.pending {
-		nonce, err := pool.currentState.GetNonce(addr)
-		if err != nil {
-			log.Error("Failed to get nonce", "err", err)
-		}
+		nonce := pool.currentState.GetNonce(addr)
 
 		// Drop all transactions that are deemed too old (low nonce)
 		tracing := log.Tracing()
@@ -1280,10 +1250,7 @@ func (pool *TxPool) demoteUnexecutables(ctx context.Context) {
 		pending.Forward(nonce, remove)
 
 		// Drop all transactions that are too costly (low balance or out of gas), and queue any invalids back for later
-		bal, err := pool.currentState.GetBalance(addr)
-		if err != nil {
-			log.Error("Failed to get balance", "err", err)
-		}
+		bal := pool.currentState.GetBalance(addr)
 		remove = func(tx *types.Transaction) {
 			delete(pool.all, tx.Hash())
 			pendingNofundsCounter.Inc(1)

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -24,10 +24,9 @@ import (
 	"math/big"
 	"math/rand"
 	"os"
+	"sync"
 	"testing"
 	"time"
-
-	"sync"
 
 	"github.com/gochain-io/gochain/common"
 	"github.com/gochain-io/gochain/core/state"
@@ -35,7 +34,6 @@ import (
 	"github.com/gochain-io/gochain/crypto"
 	"github.com/gochain-io/gochain/ethdb"
 	"github.com/gochain-io/gochain/event"
-	"github.com/gochain-io/gochain/log"
 	"github.com/gochain-io/gochain/params"
 )
 
@@ -131,11 +129,7 @@ func validateTxPoolInternals(pool *TxPool) error {
 				last = nonce
 			}
 		}
-		nonce, err := pool.pendingState.GetNonce(addr)
-		if err != nil {
-			log.Error("Failed to get nonce", "err", err)
-		}
-		if nonce != last+1 {
+		if nonce := pool.pendingState.GetNonce(addr); nonce != last+1 {
 			return fmt.Errorf("pending nonce mismatch: have %v, want %v", nonce, last+1)
 		}
 	}
@@ -218,20 +212,14 @@ func TestStateChangeDuringTransactionPoolReset(t *testing.T) {
 	pool := NewTxPool(ctx, testTxPoolConfig, params.TestChainConfig, blockchain)
 	defer pool.Stop()
 
-	nonce, err := pool.State().GetNonce(address)
-	if err != nil {
-		log.Error("Failed to get nonce", "err", err)
-	}
+	nonce := pool.State().GetNonce(address)
 	if nonce != 0 {
 		t.Fatalf("Invalid nonce, want 0, got %d", nonce)
 	}
 
 	pool.AddRemotes(ctx, types.Transactions{tx0, tx1})
 
-	nonce, err = pool.State().GetNonce(address)
-	if err != nil {
-		log.Error("Failed to get nonce", "err", err)
-	}
+	nonce = pool.State().GetNonce(address)
 	if nonce != 2 {
 		t.Fatalf("Invalid nonce, want 2, got %d", nonce)
 	}
@@ -247,10 +235,7 @@ func TestStateChangeDuringTransactionPoolReset(t *testing.T) {
 		t.Logf("%0x: %d\n", addr, len(txs))
 	}
 
-	nonce, err = pool.State().GetNonce(address)
-	if err != nil {
-		log.Error("Failed to get nonce", "err", err)
-	}
+	nonce = pool.State().GetNonce(address)
 	if nonce != 2 {
 		t.Fatalf("Invalid nonce, want 2, got %d", nonce)
 	}
@@ -519,12 +504,8 @@ func TestTransactionNonceRecovery(t *testing.T) {
 	defer pool.mu.Unlock()
 	pool.currentState.SetNonce(addr, n-1)
 	pool.reset(ctx, nil, nil)
-	fn, err := pool.pendingState.GetNonce(addr)
-	if err != nil {
-		log.Error("Failed to get nonce", "err", err)
-	}
-	if fn != n-1 {
-		t.Errorf("expected nonce to be %d, got %d", n-1, fn)
+	if got := pool.pendingState.GetNonce(addr); got != n-1 {
+		t.Errorf("expected nonce to be %d, got %d", n-1, got)
 	}
 }
 

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -19,7 +19,6 @@ package vm
 import (
 	"github.com/gochain-io/gochain/common"
 	"github.com/gochain-io/gochain/common/math"
-	"github.com/gochain-io/gochain/log"
 	"github.com/gochain-io/gochain/params"
 )
 
@@ -118,12 +117,9 @@ func gasReturnDataCopy(gt params.GasTable, evm *EVM, contract *Contract, stack *
 
 func gasSStore(gt params.GasTable, evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	var (
-		y, x     = stack.Back(1), stack.Back(0)
-		val, err = evm.StateDB.GetState(contract.Address(), common.BigToHash(x))
+		y, x = stack.Back(1), stack.Back(0)
+		val  = evm.StateDB.GetState(contract.Address(), common.BigToHash(x))
 	)
-	if err != nil {
-		log.Error("Failed to get state", "err", err)
-	}
 	// This checks for 3 scenario's and calculates gas accordingly
 	// 1. From a zero-value address to a non-zero value         (NEW VALUE)
 	// 2. From a non-zero value address to a zero-value address (DELETE)
@@ -398,11 +394,7 @@ func gasSuicide(gt params.GasTable, evm *EVM, contract *Contract, stack *Stack, 
 
 		if eip158 {
 			// if empty and transfers value
-			bal, err := evm.StateDB.GetBalance(contract.Address())
-			if err != nil {
-				log.Error("Failed to get balance", "err", err)
-			}
-			if evm.StateDB.Empty(address) && bal.Sign() != 0 {
+			if evm.StateDB.Empty(address) && evm.StateDB.GetBalance(contract.Address()).Sign() != 0 {
 				gas += gt.CreateBySuicide
 			}
 		} else if !evm.StateDB.Exist(address) {

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gochain-io/gochain/common/math"
 	"github.com/gochain-io/gochain/core/types"
 	"github.com/gochain-io/gochain/crypto"
-	"github.com/gochain-io/gochain/log"
 	"github.com/gochain-io/gochain/params"
 )
 
@@ -325,11 +324,7 @@ func opAddress(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *
 
 func opBalance(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	addr := common.BigToAddress(stack.pop())
-	balance, err := evm.StateDB.GetBalance(addr)
-	if err != nil {
-		log.Error("Failed to get balance", "err", err)
-	}
-
+	balance := evm.StateDB.GetBalance(addr)
 	stack.push(new(big.Int).Set(balance))
 	return nil, nil
 }
@@ -397,11 +392,7 @@ func opExtCodeSize(pc *uint64, evm *EVM, contract *Contract, memory *Memory, sta
 	a := stack.pop()
 
 	addr := common.BigToAddress(a)
-	size, err := evm.StateDB.GetCodeSize(addr)
-	if err != nil {
-		log.Error("Failed to get code size", "err", err)
-	}
-	a.SetInt64(int64(size))
+	a.SetInt64(int64(evm.StateDB.GetCodeSize(addr)))
 	stack.push(a)
 
 	return nil, nil
@@ -433,10 +424,7 @@ func opExtCodeCopy(pc *uint64, evm *EVM, contract *Contract, memory *Memory, sta
 		codeOffset = stack.pop()
 		length     = stack.pop()
 	)
-	code, err := evm.StateDB.GetCode(addr)
-	if err != nil {
-		log.Error("Failed to get code", "err", err)
-	}
+	code := evm.StateDB.GetCode(addr)
 	codeCopy := getDataBig(code, codeOffset, length)
 	memory.Set(memOffset.Uint64(), length.Uint64(), codeCopy)
 
@@ -520,10 +508,7 @@ func opMstore8(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *
 
 func opSload(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	loc := common.BigToHash(stack.pop())
-	st, err := evm.StateDB.GetState(contract.Address(), loc)
-	if err != nil {
-		log.Error("Failed to get state", "err", err)
-	}
+	st := evm.StateDB.GetState(contract.Address(), loc)
 	val := st.Big()
 	stack.push(val)
 	return nil, nil
@@ -747,10 +732,7 @@ func opStop(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Sta
 }
 
 func opSuicide(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	balance, err := evm.StateDB.GetBalance(contract.Address())
-	if err != nil {
-		log.Error("Failed to get balance", "err", err)
-	}
+	balance := evm.StateDB.GetBalance(contract.Address())
 	evm.StateDB.AddBalance(common.BigToAddress(stack.pop()), balance)
 
 	evm.StateDB.Suicide(contract.Address())

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -29,20 +29,24 @@ type StateDB interface {
 
 	SubBalance(common.Address, *big.Int)
 	AddBalance(common.Address, *big.Int)
-	GetBalance(common.Address) (*big.Int, error)
+	GetBalance(common.Address) *big.Int
+	GetBalanceErr(common.Address) (*big.Int, error)
 
-	GetNonce(common.Address) (uint64, error)
+	GetNonce(common.Address) uint64
+	GetNonceErr(common.Address) (uint64, error)
 	SetNonce(common.Address, uint64)
 
-	GetCodeHash(common.Address) (common.Hash, error)
-	GetCode(common.Address) ([]byte, error)
+	GetCodeHash(common.Address) common.Hash
+	GetCode(common.Address) []byte
+	GetCodeErr(common.Address) ([]byte, error)
 	SetCode(common.Address, []byte)
-	GetCodeSize(common.Address) (int, error)
+	GetCodeSize(common.Address) int
 
 	AddRefund(uint64)
 	GetRefund() uint64
 
-	GetState(common.Address, common.Hash) (common.Hash, error)
+	GetState(common.Address, common.Hash) common.Hash
+	GetStateErr(common.Address, common.Hash) (common.Hash, error)
 	SetState(common.Address, common.Hash, common.Hash)
 
 	Suicide(common.Address) bool

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -168,7 +168,7 @@ func (b *EthApiBackend) GetPoolTransaction(hash common.Hash) *types.Transaction 
 }
 
 func (b *EthApiBackend) GetPoolNonce(ctx context.Context, addr common.Address) (uint64, error) {
-	return b.eth.txPool.State().GetNonce(addr)
+	return b.eth.txPool.State().GetNonce(addr), nil
 }
 
 func (b *EthApiBackend) Stats() (pending int, queued int) {

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gochain-io/gochain/crypto"
 	"github.com/gochain-io/gochain/eth/downloader"
 	"github.com/gochain-io/gochain/ethdb"
-	"github.com/gochain-io/gochain/log"
 	"github.com/gochain-io/gochain/p2p"
 	"github.com/gochain-io/gochain/params"
 )
@@ -378,15 +377,8 @@ func testGetNodeData(t *testing.T, protocol int) {
 
 		for j, acc := range accounts {
 			state, _ := pm.blockchain.State()
-			bw, err := state.GetBalance(acc)
-			if err != nil {
-				log.Error("Failed to get balance", "err", err)
-			}
-			bh, err := trie.GetBalance(acc)
-			if err != nil {
-				log.Error("Failed to get balance", "err", err)
-			}
-
+			bw := state.GetBalance(acc)
+			bh := trie.GetBalance(acc)
 			if (bw != nil && bh == nil) || (bw == nil && bh != nil) {
 				t.Errorf("test %d, account %d: balance mismatch: have %v, want %v", i, j, bh, bw)
 			}

--- a/eth/tracers/tracer.go
+++ b/eth/tracers/tracer.go
@@ -187,10 +187,7 @@ func (dw *dbWrapper) pushObject(vm *duktape.Context) {
 
 	// Push the wrapper for statedb.GetBalance
 	vm.PushGoFunction(func(ctx *duktape.Context) int {
-		bal, err := dw.db.GetBalance(common.BytesToAddress(popSlice(ctx)))
-		if err != nil {
-			log.Error("Failed to get balance", "err", err)
-		}
+		bal := dw.db.GetBalance(common.BytesToAddress(popSlice(ctx)))
 		pushBigInt(bal, ctx)
 		return 1
 	})
@@ -198,10 +195,7 @@ func (dw *dbWrapper) pushObject(vm *duktape.Context) {
 
 	// Push the wrapper for statedb.GetNonce
 	vm.PushGoFunction(func(ctx *duktape.Context) int {
-		nonce, err := dw.db.GetNonce(common.BytesToAddress(popSlice(ctx)))
-		if err != nil {
-			log.Error("Failed to get nonce", "err", err)
-		}
+		nonce := dw.db.GetNonce(common.BytesToAddress(popSlice(ctx)))
 		ctx.PushInt(int(nonce))
 		return 1
 	})
@@ -209,10 +203,7 @@ func (dw *dbWrapper) pushObject(vm *duktape.Context) {
 
 	// Push the wrapper for statedb.GetCode
 	vm.PushGoFunction(func(ctx *duktape.Context) int {
-		code, err := dw.db.GetCode(common.BytesToAddress(popSlice(ctx)))
-		if err != nil {
-			log.Error("Failed to get code", "err", err)
-		}
+		code := dw.db.GetCode(common.BytesToAddress(popSlice(ctx)))
 
 		ptr := ctx.PushFixedBuffer(len(code))
 		copy(makeSlice(ptr, uint(len(code))), code[:])
@@ -225,10 +216,7 @@ func (dw *dbWrapper) pushObject(vm *duktape.Context) {
 		hash := popSlice(ctx)
 		addr := popSlice(ctx)
 
-		state, err := dw.db.GetState(common.BytesToAddress(addr), common.BytesToHash(hash))
-		if err != nil {
-			log.Error("Failed to get state", "err", err)
-		}
+		state := dw.db.GetState(common.BytesToAddress(addr), common.BytesToHash(hash))
 
 		ptr := ctx.PushFixedBuffer(len(state))
 		copy(makeSlice(ptr, uint(len(state))), state[:])

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -498,7 +498,7 @@ func (s *PublicBlockChainAPI) BlockNumber() *big.Int {
 func (s *PublicBlockChainAPI) GetBalance(ctx context.Context, address common.Address, blockNr rpc.BlockNumber) (*big.Int, error) {
 	var bal *big.Int
 	err := s.b.StateQuery(ctx, blockNr, func(state *state.StateDB) (err error) {
-		bal, err = state.GetBalance(address)
+		bal, err = state.GetBalanceErr(address)
 		return
 	})
 	return bal, err
@@ -585,7 +585,7 @@ func (s *PublicBlockChainAPI) GetUncleCountByBlockHash(ctx context.Context, bloc
 func (s *PublicBlockChainAPI) GetCode(ctx context.Context, address common.Address, blockNr rpc.BlockNumber) (hexutil.Bytes, error) {
 	var code hexutil.Bytes
 	err := s.b.StateQuery(ctx, blockNr, func(state *state.StateDB) (err error) {
-		code, err = state.GetCode(address)
+		code, err = state.GetCodeErr(address)
 		return
 	})
 	return code, err
@@ -597,7 +597,7 @@ func (s *PublicBlockChainAPI) GetCode(ctx context.Context, address common.Addres
 func (s *PublicBlockChainAPI) GetStorageAt(ctx context.Context, address common.Address, key string, blockNr rpc.BlockNumber) (hexutil.Bytes, error) {
 	var st common.Hash
 	err := s.b.StateQuery(ctx, blockNr, func(state *state.StateDB) (err error) {
-		st, err = state.GetState(address, common.HexToHash(key))
+		st, err = state.GetStateErr(address, common.HexToHash(key))
 		return
 	})
 	return st[:], err
@@ -997,7 +997,7 @@ func (s *PublicTransactionPoolAPI) GetRawTransactionByBlockHashAndIndex(ctx cont
 func (s *PublicTransactionPoolAPI) GetTransactionCount(ctx context.Context, address common.Address, blockNr rpc.BlockNumber) (*hexutil.Uint64, error) {
 	var nonce uint64
 	err := s.b.StateQuery(ctx, blockNr, func(state *state.StateDB) (err error) {
-		nonce, err = state.GetNonce(address)
+		nonce, err = state.GetNonceErr(address)
 		return
 	})
 	return (*hexutil.Uint64)(&nonce), err

--- a/les/odr_test.go
+++ b/les/odr_test.go
@@ -96,7 +96,7 @@ func odrAccounts(ctx context.Context, db ethdb.Database, config *params.ChainCon
 			st = light.NewState(ctx, header, lc.Odr())
 		}
 		if err == nil {
-			bal, _ := st.GetBalance(addr)
+			bal := st.GetBalance(addr)
 			rlp, _ := rlp.EncodeToBytes(bal)
 			res = append(res, rlp...)
 		}

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -136,14 +136,8 @@ func odrAccounts(ctx context.Context, db ethdb.Database, bc *core.BlockChain, lc
 
 	var res []byte
 	for _, addr := range acc {
-		bal, err := st.GetBalance(addr)
-		if err != nil {
-			return nil, err
-		}
-		rlp, err := rlp.EncodeToBytes(bal)
-		if err != nil {
-			return nil, err
-		}
+		bal := st.GetBalance(addr)
+		rlp, _ := rlp.EncodeToBytes(bal)
 		res = append(res, rlp...)
 	}
 	return res, nil

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -252,18 +252,9 @@ func (t *BlockTest) validatePostState(statedb *state.StateDB) error {
 	// validate post state accounts in test file against what we have in state db
 	for addr, acct := range t.json.Post {
 		// address is indirectly verified by the other fields, as it's the db key
-		code2, err := statedb.GetCode(addr)
-		if err != nil {
-			return err
-		}
-		balance2, err := statedb.GetBalance(addr)
-		if err != nil {
-			return err
-		}
-		nonce2, err := statedb.GetNonce(addr)
-		if err != nil {
-			return err
-		}
+		code2 := statedb.GetCode(addr)
+		balance2 := statedb.GetBalance(addr)
+		nonce2 := statedb.GetNonce(addr)
 		if !bytes.Equal(code2, acct.Code) {
 			return fmt.Errorf("account code mismatch for addr: %s want: %v have: %s", addr, acct.Code, hex.EncodeToString(code2))
 		}

--- a/tests/vm_test_util.go
+++ b/tests/vm_test_util.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gochain-io/gochain/core/vm"
 	"github.com/gochain-io/gochain/crypto"
 	"github.com/gochain-io/gochain/ethdb"
-	"github.com/gochain-io/gochain/log"
 	"github.com/gochain-io/gochain/params"
 )
 
@@ -102,11 +101,7 @@ func (t *VMTest) Run(vmconfig vm.Config) error {
 	}
 	for addr, account := range t.json.Post {
 		for k, wantV := range account.Storage {
-			haveV, err := statedb.GetState(addr, k)
-			if err != nil {
-				log.Error("Failed to get state", "err", err)
-			}
-			if haveV != wantV {
+			if haveV := statedb.GetState(addr, k); haveV != wantV {
 				return fmt.Errorf("wrong storage value at %x:\n  got  %x\n  want %x", k, haveV, wantV)
 			}
 		}


### PR DESCRIPTION
This change reverts and re-implements part of #136, to fix a nil panic. It restores the original method signatures and their behavior (returning zero value defaults), and adds some `*Err()` variants for the cases which actually want the errors.