### PR TITLE
eth, netstats: simplify netstats; fix logs; broadcast blocks to subset of peers only

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"sync"
 	"sync/atomic"
@@ -651,7 +652,8 @@ func (pm *ProtocolManager) BroadcastBlock(block *types.Block, propagate bool) {
 			log.Error("Propagating dangling block", "number", block.Number(), "hash", hash)
 			return
 		}
-		for _, p := range peers {
+		// Send the block to a subset of our peers.
+		for _, p := range peers[:int(math.Sqrt(float64(len(peers))))] {
 			p.SendNewBlockAsync(block, td)
 		}
 		return

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -192,14 +192,14 @@ func (p *peer) broadcast() {
 
 		case prop := <-p.queuedProps:
 			if err := p.SendNewBlock(prop.block, prop.td); err != nil {
-				p.Log().Error("Failed to propagate block", prop.block.Number(), "hash", prop.block.Hash(), "td", prop.td)
+				p.Log().Error("Failed to propagate block", "number", prop.block.Number(), "hash", prop.block.Hash(), "td", prop.td, "err", err)
 			} else {
-				p.Log().Trace("Propagated block", prop.block.Number(), "hash", prop.block.Hash(), "td", prop.td)
+				p.Log().Trace("Propagated block", "number", prop.block.Number(), "hash", prop.block.Hash(), "td", prop.td)
 			}
 
 		case block := <-p.queuedAnns:
 			if err := p.SendNewBlockHash(block.Hash(), block.NumberU64()); err != nil {
-				p.Log().Error("Failed to announce block", "number", block.Number(), "hash", block.Hash())
+				p.Log().Error("Failed to announce block", "number", block.Number(), "hash", block.Hash(), "err", err)
 			} else {
 				p.Log().Trace("Announced block", "number", block.Number(), "hash", block.Hash())
 			}

--- a/netstats/netstats.go
+++ b/netstats/netstats.go
@@ -175,9 +175,8 @@ func (s *Service) loop() {
 		txCh   = make(chan struct{}, 1)
 	)
 	go func() {
+		defer close(quitCh)
 		var lastTx mclock.AbsTime
-
-	HandleLoop:
 		for {
 			select {
 			// Notify of chain head events, but drop if too frequent
@@ -201,12 +200,11 @@ func (s *Service) loop() {
 
 			// node stopped
 			case <-txSub.Err():
-				break HandleLoop
+				return
 			case <-headSub.Err():
-				break HandleLoop
+				return
 			}
 		}
-		close(quitCh)
 	}()
 	// Loop reporting until termination
 	for {


### PR DESCRIPTION
This PR contains some cleanup from recent changes.