### PR TITLE
p2p: log disc msg when decoding fails, and return meaningful error instead of default

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -25,6 +25,8 @@ import (
 	"sync"
 	"time"
 
+	"encoding/hex"
+
 	"github.com/gochain-io/gochain/common/mclock"
 	"github.com/gochain-io/gochain/event"
 	"github.com/gochain-io/gochain/log"
@@ -286,7 +288,7 @@ func (p *Peer) handle(msg Msg) error {
 		// This is the last message. We don't need to discard or
 		// check errors because, the connection will be closed after it.
 		if err := rlp.Decode(buf, &reason); err != nil {
-			p.Log().Error("Cannot decode disc msg payload", "msg", buf.String(), "err", err)
+			p.Log().Error("Cannot decode disc msg payload", "msg", hex.EncodeToString(buf.Bytes()), "err", err)
 			return fmt.Errorf("failed to decode disc msg: %s", err)
 		}
 		return reason[0]

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -35,6 +35,8 @@ import (
 	"sync"
 	"time"
 
+	"encoding/hex"
+
 	"github.com/gochain-io/gochain/crypto"
 	"github.com/gochain-io/gochain/crypto/ecies"
 	"github.com/gochain-io/gochain/crypto/secp256k1"
@@ -171,7 +173,7 @@ func readProtocolHandshake(rw MsgReader, our *protoHandshake) (*protoHandshake, 
 		// back otherwise. Wrap it in a string instead.
 		var reason [1]DiscReason
 		if err := rlp.Decode(buf, &reason); err != nil {
-			log.Error("Cannot decode rlpx disc msg", "msg", buf.String(), "err", err)
+			log.Error("Cannot decode rlpx disc msg", "msg", hex.EncodeToString(buf.Bytes()), "err", err)
 			return nil, fmt.Errorf("failed to decode disc msg: %s", err)
 		}
 		return nil, reason[0]


### PR DESCRIPTION
This PR aims to improve the handling of this situation:
```
ERROR[05-24|15:56:17] Cannot decode rlpx disc msg              err="rlp: input list has too many elements for [1]p2p.DiscReason"
```
It is an incremental improvement to both:
- log the message which we failed to decode (might reveal the complete fix)
- return a meaningful error to the caller, instead of the `DiscReason` zero value