### PR TITLE
p2p: reduce severity of rlpx read/write deadline errors

### DIFF
--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -88,7 +88,7 @@ type rlpx struct {
 
 func newRLPX(fd net.Conn) transport {
 	if err := fd.SetDeadline(time.Now().Add(handshakeTimeout)); err != nil {
-		log.Error("Cannot set rlpx deadline", "err", err)
+		log.Info("Failed to set rlpx deadline", "err", err)
 	}
 	return &rlpx{fd: fd}
 }
@@ -97,7 +97,7 @@ func (t *rlpx) ReadMsg() (Msg, error) {
 	t.rmu.Lock()
 	defer t.rmu.Unlock()
 	if err := t.fd.SetReadDeadline(time.Now().Add(frameReadTimeout)); err != nil {
-		log.Error("Cannot set rlpx read deadline", "err", err)
+		log.Info("Failed to set rlpx read deadline", "err", err)
 	}
 	return t.rw.ReadMsg()
 }
@@ -118,15 +118,15 @@ func (t *rlpx) close(err error) {
 	if t.rw != nil {
 		if r, ok := err.(DiscReason); ok && r != DiscNetworkError {
 			if err := t.fd.SetWriteDeadline(time.Now().Add(discWriteTimeout)); err != nil {
-				log.Error("Cannot set rlpx write deadline while closing", "err", err)
+				log.Info("Failed to set rlpx write deadline while closing", "err", err)
 			}
 			if err := SendItems(t.rw, discMsg, r); err != nil {
-				log.Error("Cannot send rlpx disc msg while closing", "err", err)
+				log.Info("Failed to send rlpx disc msg while closing", "err", err)
 			}
 		}
 	}
 	if err := t.fd.Close(); err != nil {
-		log.Error("Cannot close rlpx file descriptor", "err", err)
+		log.Error("Failed to close rlpx file descriptor", "err", err)
 	}
 }
 


### PR DESCRIPTION
These are noisy and part of normal processing (nothing short-circuits, they all continue after logging the 'error'), so switch them to `INFO` level.
```
ERROR[05-24|17:35:19] Cannot send rlpx disc msg while closing  err="write tcp 172.18.0.2:59320->206.189.76.61:30303: write: connection reset by peer"
ERROR[05-24|17:35:24] Cannot send rlpx disc msg while closing  err="write tcp 172.18.0.2:40418->148.153.48.203:30303: write: connection reset by peer"
ERROR[05-24|17:35:40] Cannot send rlpx disc msg while closing  err="write tcp 172.18.0.2:30303->94.130.106.254:60954: write: connection reset by peer"
ERROR[05-24|17:35:41] Cannot send rlpx disc msg while closing  err="write tcp 172.18.0.2:30303->88.174.119.132:54107: write: connection reset by peer"
ERROR[05-24|17:35:42] Cannot send rlpx disc msg while closing  err="write tcp 172.18.0.2:30303->207.246.69.23:39892: write: connection reset by peer"
ERROR[05-24|17:35:51] Cannot send rlpx disc msg while closing  err="write tcp 172.18.0.2:30303->88.208.34.114:42520: write: connection reset by peer"
ERROR[05-24|17:35:54] Cannot send rlpx disc msg while closing  err="write tcp 172.18.0.2:30303->47.95.32.168:44704: write: connection reset by peer"
ERROR[05-24|17:36:38] Cannot send rlpx disc msg while closing  err="write tcp 172.18.0.2:30303->209.59.156.197:53416: write: connection reset by peer"
```

I also found the message `Cannot send rlpx disc msg while closing` to be confusing, as it suggests programmer error, or bad state: `You tried to do something you cannot`, not that it was _unable_ to do what you asked, even though it was legal.

Towards #187 