### PR TITLE
cmd/utils, eth, params: align default network id with chain id

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -129,7 +129,7 @@ var (
 	}
 	NetworkIdFlag = cli.Uint64Flag{
 		Name:  "networkid",
-		Usage: "Network identifier (integer, 31337=testnet)",
+		Usage: "Network identifier (integer, 60=mainnet, 31337=testnet)",
 		Value: eth.DefaultConfig.NetworkId,
 	}
 	TestnetFlag = cli.BoolFlag{
@@ -1083,7 +1083,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	switch {
 	case ctx.GlobalBool(TestnetFlag.Name):
 		if !ctx.GlobalIsSet(NetworkIdFlag.Name) {
-			cfg.NetworkId = 31337
+			cfg.NetworkId = params.TestnetChainID
 		}
 		cfg.Genesis = core.DefaultTestnetGenesisBlock()
 	case ctx.GlobalBool(DeveloperFlag.Name):

--- a/eth/config.go
+++ b/eth/config.go
@@ -44,7 +44,7 @@ var DefaultConfig = Config{
 		DatasetsInMem:  1,
 		DatasetsOnDisk: 2,
 	},
-	NetworkId:     1,
+	NetworkId:     params.MainnetChainID,
 	LightPeers:    100,
 	DatabaseCache: 768,
 	TrieCache:     256,

--- a/eth/protocol_test.go
+++ b/eth/protocol_test.go
@@ -66,7 +66,7 @@ func testStatusMsgErrors(t *testing.T, protocol int) {
 		},
 		{
 			code: StatusMsg, data: statusData{uint32(protocol), 999, td, head.Hash(), genesis.Hash()},
-			wantError: errResp(ErrNetworkIdMismatch, "999 (!= 1)"),
+			wantError: errResp(ErrNetworkIdMismatch, "999 (!= %d)", DefaultConfig.NetworkId),
 		},
 		{
 			code: StatusMsg, data: statusData{uint32(protocol), DefaultConfig.NetworkId, td, head.Hash(), common.Hash{3}},

--- a/params/config.go
+++ b/params/config.go
@@ -28,10 +28,15 @@ var (
 	TestnetGenesisHash = common.HexToHash("0x84337e882fad5883e2ed6e587ab5bdf711b7107a39abe8e080784bb30c8f047e")
 )
 
+const (
+	MainnetChainID = 60
+	TestnetChainID = 31337
+)
+
 var (
 	// MainnetChainConfig is the chain parameters to run a node on the main network.
 	MainnetChainConfig = &ChainConfig{
-		ChainId:        big.NewInt(60),
+		ChainId:        big.NewInt(MainnetChainID),
 		HomesteadBlock: big.NewInt(0),
 		EIP150Block:    big.NewInt(0),
 		EIP150Hash:     common.Hash{},
@@ -47,7 +52,7 @@ var (
 
 	// TestnetChainConfig contains the chain parameters to run a node on the test network.
 	TestnetChainConfig = &ChainConfig{
-		ChainId:        big.NewInt(31337),
+		ChainId:        big.NewInt(TestnetChainID),
 		HomesteadBlock: big.NewInt(0),
 		EIP150Block:    big.NewInt(0),
 		EIP150Hash:     common.Hash{},


### PR DESCRIPTION
This PR changes the default `network id` from `1` to `60`, to align with `chain id`, which is necessary to support libraries that assume they are equal.