### PR TITLE
core: restore async txFeed.Send

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1026,7 +1026,7 @@ func (pool *TxPool) promoteExecutablesAll() {
 	}
 	// Notify subsystem for new promoted transactions.
 	if len(event.Txs) > 0 {
-		pool.txFeed.Send(event)
+		go pool.txFeed.Send(event)
 	}
 	pool.finishPromotion()
 }
@@ -1049,7 +1049,7 @@ func (pool *TxPool) promoteExecutables(accounts ...common.Address) {
 	}
 	// Notify subsystem for new promoted transactions.
 	if len(event.Txs) > 0 {
-		pool.txFeed.Send(event)
+		go pool.txFeed.Send(event)
 	}
 	pool.finishPromotion()
 }


### PR DESCRIPTION
This PR restores the async `txFeed` sends. This should reduce the workload while holding the pool lock and prevent feed lock up (workaround in #194), at the cost of less strict ordering of the `NewTxsEvent`s. They are batched now and the consumers of the feed are better behaved, so go routines shouldn't pile up waiting to send like they used to.