### PR TITLE
cmd, core: consolidate gas limit flags - drop txpool.pricelimit in favor of gasprice

### DIFF
--- a/cmd/gochain/main.go
+++ b/cmd/gochain/main.go
@@ -76,7 +76,6 @@ var (
 		utils.TxPoolNoLocalsFlag,
 		utils.TxPoolJournalFlag,
 		utils.TxPoolRejournalFlag,
-		utils.TxPoolPriceLimitFlag,
 		utils.TxPoolPriceBumpFlag,
 		utils.TxPoolAccountSlotsFlag,
 		utils.TxPoolGlobalSlotsFlag,
@@ -304,8 +303,6 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 				th.SetThreads(threads)
 			}
 		}
-		// Set the gas price to the limits from the CLI and start mining
-		gochain.TxPool().SetGasPrice(context.TODO(), utils.GlobalBig(ctx, utils.GasPriceFlag.Name))
 		if err := gochain.StartMining(context.TODO(), true); err != nil {
 			utils.Fatalf("Failed to start mining: %v", err)
 		}

--- a/cmd/gochain/usage.go
+++ b/cmd/gochain/usage.go
@@ -115,7 +115,6 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.TxPoolNoLocalsFlag,
 			utils.TxPoolJournalFlag,
 			utils.TxPoolRejournalFlag,
-			utils.TxPoolPriceLimitFlag,
 			utils.TxPoolPriceBumpFlag,
 			utils.TxPoolAccountSlotsFlag,
 			utils.TxPoolGlobalSlotsFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -256,11 +256,6 @@ var (
 		Usage: "Time interval to regenerate the local transaction journal",
 		Value: core.DefaultTxPoolConfig.Rejournal,
 	}
-	TxPoolPriceLimitFlag = cli.Uint64Flag{
-		Name:  "txpool.pricelimit",
-		Usage: "Minimum gas price limit to enforce for acceptance into the pool",
-		Value: eth.DefaultConfig.TxPool.PriceLimit,
-	}
 	TxPoolPriceBumpFlag = cli.Uint64Flag{
 		Name:  "txpool.pricebump",
 		Usage: "Price bump percentage to replace an already existing transaction",
@@ -333,7 +328,7 @@ var (
 	}
 	GasPriceFlag = BigFlag{
 		Name:  "gasprice",
-		Usage: "Minimal gas price to accept for mining a transactions",
+		Usage: "Minimal gas price to accept in to the pool and for mining.",
 		Value: eth.DefaultConfig.GasPrice,
 	}
 	ExtraDataFlag = cli.StringFlag{
@@ -902,8 +897,8 @@ func setTxPool(ctx *cli.Context, cfg *core.TxPoolConfig) {
 	if ctx.GlobalIsSet(TxPoolRejournalFlag.Name) {
 		cfg.Rejournal = ctx.GlobalDuration(TxPoolRejournalFlag.Name)
 	}
-	if ctx.GlobalIsSet(TxPoolPriceLimitFlag.Name) {
-		cfg.PriceLimit = ctx.GlobalUint64(TxPoolPriceLimitFlag.Name)
+	if ctx.GlobalIsSet(GasPriceFlag.Name) {
+		cfg.PriceLimit = ctx.GlobalUint64(GasPriceFlag.Name)
 	}
 	if ctx.GlobalIsSet(TxPoolPriceBumpFlag.Name) {
 		cfg.PriceBump = ctx.GlobalUint64(TxPoolPriceBumpFlag.Name)

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gochain-io/gochain/common"
 	"github.com/gochain-io/gochain/core/state"
 	"github.com/gochain-io/gochain/core/types"
+	"github.com/gochain-io/gochain/eth/gasprice"
 	"github.com/gochain-io/gochain/event"
 	"github.com/gochain-io/gochain/log"
 	"github.com/gochain-io/gochain/metrics"
@@ -157,7 +158,7 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	Journal:   "transactions.rlp",
 	Rejournal: time.Hour,
 
-	PriceLimit: 1,
+	PriceLimit: gasprice.Default.Uint64(),
 	PriceBump:  10,
 
 	AccountSlots: 2048,

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -44,6 +44,7 @@ var testTxPoolConfig TxPoolConfig
 func init() {
 	testTxPoolConfig = DefaultTxPoolConfig
 	testTxPoolConfig.Journal = ""
+	testTxPoolConfig.PriceLimit = 1
 }
 
 type testBlockChain struct {


### PR DESCRIPTION
The *transaction pool* gas limit and the *mining* gas limit were two separate cmd line flags, with different defaults. When mining, the limit configured for mining was passed along to the transaction pool, making the pool's setting irrelevant. On the other hand, the pool uses it's own setting when not mining, making the miner setting irrelevant. In practice, this results in proxies accepting txs with prices too low to be accepted by the signers, and those txs remain 'stuck' in pending on the proxy, never to be included in a block.

This PR removes the `txpool.pricelimit` flag, and uses the `gasprice` flag to set both the mining and pool limits, whether or not the node is mining. This will align the proxy limits with the signers, and txs with prices too low for the signers will be rejected up front by the proxies, before ever entering the pool.