### PR TITLE
eth, miner: nil check working pending block

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -62,6 +62,9 @@ func (b *EthApiBackend) HeaderByNumber(ctx context.Context, blockNr rpc.BlockNum
 	// Pending block is only known by the miner
 	if blockNr == rpc.PendingBlockNumber {
 		block := b.eth.miner.PendingBlock()
+		if block == nil {
+			return nil, nil
+		}
 		return block.Header(), nil
 	}
 	// Otherwise resolve and return the block

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -216,6 +216,9 @@ func (w *worker) pendingBlock() *types.Block {
 
 	w.currentMu.RLock()
 	defer w.currentMu.RUnlock()
+	if w.current == nil {
+		return nil
+	}
 	return w.current.Block
 }
 


### PR DESCRIPTION
This PR fixes a panic discovered while testing `--dev` mode. Perhaps only affects an obscure edge case of querying for pending while mining block 1.