### PR TITLE
core: order and batch txFeed sends from pool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.0
 defaults: &defaults
   working_directory: /go/src/github.com/gochain-io/gochain
   docker:
-    - image: circleci/golang:1.10.2
+    - image: circleci/golang:1.10.3
   environment: # apparently expansion doesn't work here yet: https://discuss.circleci.com/t/environment-variable-expansion-in-working-directory/11322
     - OS=linux
     - ARCH=amd64

--- a/core/database_util_test.go
+++ b/core/database_util_test.go
@@ -18,7 +18,6 @@ package core
 
 import (
 	"bytes"
-	"context"
 	"math/big"
 	"testing"
 
@@ -289,7 +288,6 @@ func TestHeadStorage(t *testing.T) {
 
 // Tests that positional lookup metadata can be stored and retrieved.
 func TestLookupStorage(t *testing.T) {
-	ctx := context.Background()
 	db := ethdb.NewMemDatabase()
 
 	tx1 := types.NewTransaction(1, common.BytesToAddress([]byte{0x11}), big.NewInt(111), 1111, big.NewInt(11111), []byte{0x11, 0x11, 0x11})
@@ -319,7 +317,7 @@ func TestLookupStorage(t *testing.T) {
 			if hash != block.Hash() || number != block.NumberU64() || index != uint64(i) {
 				t.Fatalf("tx #%d [%x]: positional metadata mismatch: have %x/%d/%d, want %x/%v/%v", i, tx.Hash(), hash, number, index, block.Hash(), block.NumberU64(), i)
 			}
-			if tx.String(ctx) != txn.String(ctx) {
+			if tx.Hash() != txn.Hash() {
 				t.Fatalf("tx #%d [%x]: transaction mismatch: have %v, want %v", i, tx.Hash(), txn, tx)
 			}
 		}

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -251,6 +251,7 @@ func (m *txSortedMap) Ready(start uint64, fn func(*types.Transaction)) {
 		}
 		delete(m.items, nonce)
 		fn(item)
+		next++
 	}
 	// Rebuild heap.
 	*m.index = make([]uint64, 0, len(m.items))
@@ -423,7 +424,7 @@ func (l *txList) Remove(tx *types.Transaction, invalid func(*types.Transaction))
 // and calling fn for each one.
 //
 // Note, all transactions with nonces lower than start will also be included to
-// prevent getting into and invalid state. This is not something that should ever
+// prevent getting into an invalid state. This is not something that should ever
 // happen but better to be self correcting than failing!
 func (l *txList) Ready(start uint64, fn func(*types.Transaction)) {
 	l.txs.Ready(start, fn)

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -267,13 +267,13 @@ func (tx *Transaction) RawSignatureValues() (*big.Int, *big.Int, *big.Int) {
 	return tx.data.V, tx.data.R, tx.data.S
 }
 
-func (tx *Transaction) String(ctx context.Context) string {
+func (tx *Transaction) String() string {
 	var from, to string
 	if tx.data.V != nil {
 		// make a best guess about the signer and use that to derive
 		// the sender.
 		signer := deriveSigner(tx.data.V)
-		if f, err := Sender(ctx, signer, tx); err != nil { // derive but don't cache
+		if f, err := Sender(context.Background(), signer, tx); err != nil { // derive but don't cache
 			from = "[invalid sender: invalid sig]"
 		} else {
 			from = fmt.Sprintf("%x", f[:])

--- a/mobile/types.go
+++ b/mobile/types.go
@@ -253,8 +253,7 @@ func (tx *Transaction) EncodeJSON() (string, error) {
 // String implements the fmt.Stringer interface to print some semi-meaningful
 // data dump of the transaction for debugging purposes.
 func (tx *Transaction) String() string {
-	ctx := context.TODO()
-	return tx.tx.String(ctx)
+	return tx.tx.String()
 }
 
 func (tx *Transaction) GetData() []byte      { return tx.tx.Data() }


### PR DESCRIPTION
This PR introduces a buffered channel and dedicated goroutine to manage the tx pool feed sends. When these were sent synchronously, they blocked up while holding a lock. When spawned in a goroutine (like before this change), they get out of order and can fill up memory. With this change, first a synchronous channel send is attempted, and if the buffer is full then a goroutine is spawned like before. Meanwhile, a dedicated goroutine continuously receives and batches txs from the buffer channel to actually send to the feed. Now the lock is never held during a feed send, and txs are batched up in the general case, instead of just batch adds. We also maintain order as long as the buffer is large enough. This should speed things up a bit, and make the pools healthier by keeping better nonce ordering. 