### PR TITLE
eth/peer: BroadcastTxs to any peers; don't limit to sqrt(len)

### DIFF
--- a/eth/peer.go
+++ b/eth/peer.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"math"
 	"math/big"
 	"sync"
 	"time"
@@ -555,7 +554,6 @@ func (ps *peerSet) PeersWithoutTxs(txs types.Transactions) map[*peer]types.Trans
 	ps.lock.RLock()
 	defer ps.lock.RUnlock()
 
-	max := int(math.Sqrt(float64(len(ps.peers))))
 	for _, tx := range txs {
 		hash := tx.Hash()
 		var count int
@@ -565,14 +563,10 @@ func (ps *peerSet) PeersWithoutTxs(txs types.Transactions) map[*peer]types.Trans
 			}
 			peerTxs[p] = append(peerTxs[p], tx)
 			count++
-			if count >= max {
-				break
-			}
 		}
-		if !tracing || count == 0 {
-			continue
+		if tracing && count > 0 {
+			log.Trace("Broadcast transaction", "hash", hash, "recipients", count)
 		}
-		log.Trace("Broadcast transaction", "hash", hash, "recipients", count)
 	}
 	return peerTxs
 }


### PR DESCRIPTION
This PR restores broadcasting transactions to *all* peers, instead of limiting to a subset (was `sqrt(len(peers))`). This should help maintain similar tx pools across the nodes in the network, and produce more consistent blocks, like this:
![screenshot from 2018-07-16 11-33-18](https://user-images.githubusercontent.com/1194128/42771227-16e5a838-88ec-11e8-9cb3-0c17826dcc82.png)
Instead of this:
![screenshot from 2018-07-16 11-33-22](https://user-images.githubusercontent.com/1194128/42771230-189e819a-88ec-11e8-8fd4-6498fe4125ae.png)


Related: #180 