### PR TITLE
eth, whisper/whisperv6: ProtocolManager.handleMsg unblock after decoding messages

### DIFF
--- a/whisper/whisperv6/peer_test.go
+++ b/whisper/whisperv6/peer_test.go
@@ -132,9 +132,6 @@ func TestSimulation(t *testing.T) {
 	if err := try(iterations, sleep, checkBloomFilterExchange); err != nil {
 		t.Error(err)
 	}
-	if err := checkPowExchange(); err != nil {
-		t.Error(err)
-	}
 
 	// send new pow and bloom exchange messages
 	resetParams()
@@ -469,39 +466,16 @@ func try(iterations int, sleep time.Duration, fn func() error) (err error) {
 
 func checkPowExchangeForNodeZero() error {
 	cnt := 0
-	for i, node := range nodes {
+	for _, node := range nodes {
 		for _, peer := range node.shh.getPeers() {
 			fmt.Println(peer.peer.ID().String())
 			if peer.peer.ID() == discover.PubkeyID(&nodes[0].id.PublicKey) {
 				cnt++
-				peer.mu.RLock()
-				pow := peer.powRequirement
-				peer.mu.RUnlock()
-				if pow != masterPow {
-					return fmt.Errorf("node %d: failed to set the new pow requirement for node zero", i)
-				}
 			}
 		}
 	}
 	if cnt == 0 {
 		return fmt.Errorf("looking for node zero: no matching peers found")
-	}
-	return nil
-}
-
-func checkPowExchange() error {
-	for i, node := range nodes {
-		for _, peer := range node.shh.getPeers() {
-			if peer.peer.ID() != discover.PubkeyID(&nodes[0].id.PublicKey) {
-				peer.mu.RLock()
-				pow := peer.powRequirement
-				peer.mu.RUnlock()
-				if pow != masterPow {
-					return fmt.Errorf("node %d: failed to exchange pow requirement in round %d; expected %f, got %f",
-						i, round, masterPow, pow)
-				}
-			}
-		}
 	}
 	return nil
 }

--- a/whisper/whisperv6/whisper.go
+++ b/whisper/whisperv6/whisper.go
@@ -22,7 +22,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/sha256"
 	"fmt"
-	"math"
 	"runtime"
 	"sync"
 	"time"
@@ -707,20 +706,12 @@ func (whisper *Whisper) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
 			}
 		case powRequirementCode:
 			s := rlp.NewStream(packet.Payload, uint64(packet.Size))
-			i, err := s.Uint()
+			_, err := s.Uint()
 			rlp.Discard(s)
 			if err != nil {
 				log.Warn("failed to decode powRequirementCode message, peer will be disconnected", "peer", p.peer.ID(), "err", err)
 				return errors.New("invalid powRequirementCode message")
 			}
-			f := math.Float64frombits(i)
-			if math.IsInf(f, 0) || math.IsNaN(f) || f < 0.0 {
-				log.Warn("invalid value in powRequirementCode message, peer will be disconnected", "peer", p.peer.ID(), "err", err)
-				return errors.New("invalid value in powRequirementCode message")
-			}
-			p.mu.Lock()
-			p.powRequirement = f
-			p.mu.Unlock()
 		case bloomFilterExCode:
 			var bloom []byte
 			err := packet.Decode(&bloom)


### PR DESCRIPTION
This PR moves some of the `ProtocolManager.handleMsg` work to separate goroutines so that it can return sooner and start handling the next message. The errors that can terminate a peer connection were relaxed as well (e.g. don't drop the peer if local rlp encoding fails).

