### PR TITLE
core: BlockChain.insertChain - validate body before locking

### DIFF
--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -259,8 +259,6 @@ func (c *Clique) VerifyHeader(ctx context.Context, chain consensus.ChainReader, 
 // method returns a quit channel to abort the operations and a results channel to
 // retrieve the async verifications (the order is that of the input slice).
 func (c *Clique) VerifyHeaders(ctx context.Context, chain consensus.ChainReader, headers []*types.Header) (chan<- struct{}, <-chan error) {
-	ctx, span := trace.StartSpan(ctx, "Clique.VerifyHeaders")
-	defer span.End()
 	verify := []verifyFn{c.verifyHeader, c.verifyCascadingFields, c.verifySeal}
 	return c.verifyHeaders(ctx, chain, headers, verify)
 }
@@ -270,6 +268,9 @@ func (c *Clique) verifyHeaders(ctx context.Context, chain consensus.ChainReader,
 	results := make(chan error, len(headers))
 
 	go func() {
+		ctx, span := trace.StartSpan(context.Background(), "Clique.verifyHeaders")
+		defer span.End()
+		defer close(results)
 		for i, header := range headers {
 			parents := headers[:i]
 			var err error

--- a/core/block_validator_test.go
+++ b/core/block_validator_test.go
@@ -76,8 +76,10 @@ func TestHeaderVerification(t *testing.T) {
 			}
 			// Make sure no more data is returned
 			select {
-			case result := <-results:
-				t.Fatalf("test %d.%d: unexpected result returned: %v", i, j, result)
+			case result, ok := <-results:
+				if ok {
+					t.Fatalf("test %d.%d: unexpected result returned: %v", i, j, result)
+				}
 			case <-time.After(25 * time.Millisecond):
 			}
 		}
@@ -156,8 +158,10 @@ func testHeaderConcurrentVerification(t *testing.T, threads int) {
 		}
 		// Make sure no more data is returned
 		select {
-		case result := <-results:
-			t.Fatalf("test %d: unexpected result returned: %v", i, result)
+		case result, ok := <-results:
+			if ok {
+				t.Fatalf("test %d: unexpected result returned: %v", i, result)
+			}
 		case <-time.After(25 * time.Millisecond):
 		}
 	}
@@ -200,7 +204,11 @@ func testHeaderConcurrentAbortion(t *testing.T, threads int) {
 	verified := 0
 	for depleted := false; !depleted; {
 		select {
-		case result := <-results:
+		case result, ok := <-results:
+			if !ok {
+				depleted = true
+				break
+			}
 			if result != nil {
 				t.Errorf("header %d: validation failed: %v", verified, result)
 			}

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -171,11 +171,11 @@ func testFork(t *testing.T, blockchain *BlockChain, i, n int, full bool, compara
 // testBlockChainImport tries to process a chain of blocks, writing them into
 // the database if successful.
 func testBlockChainImport(ctx context.Context, chain types.Blocks, blockchain *BlockChain) error {
-	for _, block := range chain {
+	for i, block := range chain {
 		// Try and process the block
 		err := blockchain.engine.VerifyHeader(ctx, blockchain, block.Header())
 		if err == nil {
-			err = blockchain.validator.ValidateBody(ctx, block)
+			err = blockchain.validator.ValidateBody(ctx, block, i == 0)
 		}
 		if err != nil {
 			if err == ErrKnownBlock {
@@ -395,7 +395,7 @@ func testBrokenChain(t *testing.T, full bool) {
 
 type bproc struct{}
 
-func (bproc) ValidateBody(context.Context, *types.Block) error { return nil }
+func (bproc) ValidateBody(context.Context, *types.Block, bool) error { return nil }
 func (bproc) ValidateState(ctx context.Context, block, parent *types.Block, state *state.StateDB, receipts types.Receipts, usedGas uint64) error {
 	return nil
 }

--- a/core/types.go
+++ b/core/types.go
@@ -30,7 +30,7 @@ import (
 //
 type Validator interface {
 	// ValidateBody validates the given block's content.
-	ValidateBody(ctx context.Context, block *types.Block) error
+	ValidateBody(ctx context.Context, block *types.Block, checkParent bool) error
 
 	// ValidateState validates the given statedb and optionally the receipts and
 	// gas used.

--- a/core/types/derive_sha.go
+++ b/core/types/derive_sha.go
@@ -18,6 +18,9 @@ package types
 
 import (
 	"bytes"
+	"context"
+
+	"go.opencensus.io/trace"
 
 	"github.com/gochain-io/gochain/common"
 	"github.com/gochain-io/gochain/rlp"
@@ -27,6 +30,12 @@ import (
 type DerivableList interface {
 	Len() int
 	GetRlp(i int) []byte
+}
+
+func DeriveShaCtx(ctx context.Context, list DerivableList) common.Hash {
+	ctx, span := trace.StartSpan(ctx, "DeriveShaCtx")
+	defer span.End()
+	return DeriveSha(list)
 }
 
 func DeriveSha(list DerivableList) common.Hash {


### PR DESCRIPTION
Traces show that `BlockChain.insertChain` is pretty heavily serialized:
![screenshot from 2018-09-16 11-14-56](https://user-images.githubusercontent.com/1194128/45598444-e35a0180-b9a1-11e8-81cb-f1987e696bad.png)
This PR moves some block body validation into a separate goroutine, and spawns it before grabbing the lock. 
