### PR TITLE
rlp: trace encoding and decoding

### DIFF
--- a/consensus/clique/fake.go
+++ b/consensus/clique/fake.go
@@ -69,7 +69,7 @@ func (e *fakeEngine) Authorize(signer common.Address, fn consensus.SignerFn) {
 	e.real.Authorize(signer, fn)
 }
 
-func (e *fakeEngine) Author(header *types.Header) (common.Address, error) {
+func (e *fakeEngine) Author(_ context.Context, header *types.Header) (common.Address, error) {
 	return header.Coinbase, nil
 }
 

--- a/consensus/clique/snapshot.go
+++ b/consensus/clique/snapshot.go
@@ -18,6 +18,7 @@ package clique
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -181,7 +182,7 @@ func (s *Snapshot) uncast(address common.Address, authorize bool) bool {
 
 // apply creates a new authorization snapshot by applying the given headers to
 // the original one.
-func (s *Snapshot) apply(headers []*types.Header) (*Snapshot, error) {
+func (s *Snapshot) apply(ctx context.Context, headers []*types.Header) (*Snapshot, error) {
 	// Allow passing in no headers for cleaner code
 	if len(headers) == 0 {
 		return s, nil
@@ -206,7 +207,7 @@ func (s *Snapshot) apply(headers []*types.Header) (*Snapshot, error) {
 			snap.Tally = make(map[common.Address]Tally)
 		}
 		// Resolve the authorization key and check against signers
-		signer, err := ecrecover(header, s.sigcache)
+		signer, err := ecrecover(ctx, header, s.sigcache)
 		if err != nil {
 			return nil, err
 		}

--- a/consensus/clique/snapshot_test.go
+++ b/consensus/clique/snapshot_test.go
@@ -57,7 +57,7 @@ func (ap *testerAccountPool) sign(header *types.Header, signer string) {
 		ap.accounts[signer], _ = crypto.GenerateKey()
 	}
 	// Sign the header and embed the signature in extra data
-	sig, _ := crypto.Sign(sigHash(header).Bytes(), ap.accounts[signer])
+	sig, _ := crypto.Sign(sigHash(context.Background(), header).Bytes(), ap.accounts[signer])
 	header.Signer = sig
 }
 

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -55,7 +55,7 @@ type Engine interface {
 	// Author retrieves the GoChain address of the account that minted the given
 	// block, which may be different from the header's coinbase if a consensus
 	// engine is based on signatures.
-	Author(header *types.Header) (common.Address, error)
+	Author(ctx context.Context, header *types.Header) (common.Address, error)
 
 	// VerifyHeader checks whether a header conforms to the consensus rules of a
 	// given engine. Verifying the seal may be done optionally here, or explicitly

--- a/core/evm.go
+++ b/core/evm.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"context"
 	"math/big"
 
 	"github.com/gochain-io/gochain/common"
@@ -40,7 +41,7 @@ func NewEVMContext(msg Message, header *types.Header, chain ChainContext, author
 	// If we don't have an explicit author (i.e. not mining), extract from the header
 	var beneficiary common.Address
 	if author == nil {
-		beneficiary, _ = chain.Engine().Author(header) // Ignore error, we're past header validation
+		beneficiary, _ = chain.Engine().Author(context.Background(), header) // Ignore error, we're past header validation
 	} else {
 		beneficiary = *author
 	}
@@ -63,7 +64,7 @@ func NewEVMContextLite(header *types.Header, chain ChainContext, author *common.
 	// If we don't have an explicit author (i.e. not mining), extract from the header
 	var beneficiary common.Address
 	if author == nil {
-		beneficiary, _ = chain.Engine().Author(header) // Ignore error, we're past header validation
+		beneficiary, _ = chain.Engine().Author(context.Background(), header) // Ignore error, we're past header validation
 	} else {
 		beneficiary = *author
 	}

--- a/eth/fetcher/fetcher.go
+++ b/eth/fetcher/fetcher.go
@@ -670,9 +670,8 @@ func (f *Fetcher) enqueue(peer string, block *types.Block) {
 	}
 }
 
-// insert spawns a new goroutine to run a block insertion into the chain. If the
-// block's number is at the same height as the current import phase, if updates
-// the phase states accordingly.
+// insert inserts a block into the chain. It is safe to run in a separate goroutine. If the block's number
+// is at the same height as the current import phase, if updates the phase states accordingly.
 func (f *Fetcher) insert(peer string, block *types.Block) {
 	hash := block.Hash()
 	defer func() { f.done <- hash }()

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -449,7 +449,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		)
 		for bytes < softResponseLimit && len(bodies) < downloader.MaxBlockFetch {
 			// Retrieve the hash of the next block
-			if err := msgStream.Decode(&hash); err == rlp.EOL {
+			if err := msgStream.DecodeCtx(ctx, &hash); err == rlp.EOL {
 				break
 			} else if err != nil {
 				return errResp(ErrDecode, "msg %v: %v", msg, err)
@@ -500,7 +500,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		)
 		for bytes < softResponseLimit && len(data) < downloader.MaxStateFetch {
 			// Retrieve the hash of the next state entry
-			if err := msgStream.Decode(&hash); err == rlp.EOL {
+			if err := msgStream.DecodeCtx(ctx, &hash); err == rlp.EOL {
 				break
 			} else if err != nil {
 				return errResp(ErrDecode, "msg %v: %v", msg, err)
@@ -539,7 +539,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		)
 		for bytes < softResponseLimit && len(receipts) < downloader.MaxReceiptFetch {
 			// Retrieve the hash of the next block
-			if err := msgStream.Decode(&hash); err == rlp.EOL {
+			if err := msgStream.DecodeCtx(ctx, &hash); err == rlp.EOL {
 				break
 			} else if err != nil {
 				return errResp(ErrDecode, "msg %v: %v", msg, err)
@@ -552,7 +552,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 				}
 			}
 			// If known, encode and queue for response packet
-			if encoded, err := rlp.EncodeToBytes(results); err != nil {
+			if encoded, err := rlp.EncodeToBytesCtx(ctx, results); err != nil {
 				log.Error("Failed to encode receipt", "err", err)
 			} else {
 				receipts = append(receipts, encoded)

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -338,7 +338,7 @@ func (p *peer) SendNewBlockHash(ctx context.Context, hash common.Hash, number ui
 	ctx, span := trace.StartSpan(ctx, "peer.SendNewBlockHash")
 	defer span.End()
 
-	b, err := rlp.EncodeToBytes(newBlockHashesData{{Hash: hash, Number: number}})
+	b, err := rlp.EncodeToBytesCtx(ctx, newBlockHashesData{{Hash: hash, Number: number}})
 	if err != nil {
 		return err
 	}
@@ -356,7 +356,7 @@ func (p *peer) SendNewBlock(ctx context.Context, block *types.Block, td *big.Int
 	ctx, span := trace.StartSpan(ctx, "peer.SendNewBlock")
 	defer span.End()
 
-	b, err := rlp.EncodeToBytes([]interface{}{block, td})
+	b, err := rlp.EncodeToBytesCtx(ctx, []interface{}{block, td})
 	if err != nil {
 		return err
 	}

--- a/goclient/ethclient.go
+++ b/goclient/ethclient.go
@@ -476,7 +476,7 @@ func (ec *Client) EstimateGas(ctx context.Context, msg gochain.CallMsg) (uint64,
 // If the transaction was a contract creation use the TransactionReceipt method to get the
 // contract address after the transaction has been mined.
 func (ec *Client) SendTransaction(ctx context.Context, tx *types.Transaction) error {
-	data, err := rlp.EncodeToBytes(tx)
+	data, err := rlp.EncodeToBytesCtx(ctx, tx)
 	if err != nil {
 		return err
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -396,7 +396,7 @@ func (s *PrivateAccountAPI) SignTransaction(ctx context.Context, args SendTxArgs
 	if err != nil {
 		return nil, err
 	}
-	data, err := rlp.EncodeToBytes(signed)
+	data, err := rlp.EncodeToBytesCtx(ctx, signed)
 	if err != nil {
 		return nil, err
 	}
@@ -1076,7 +1076,7 @@ func (s *PublicTransactionPoolAPI) GetRawTransactionByHash(ctx context.Context, 
 		}
 	}
 	// Serialize to RLP and return
-	return rlp.EncodeToBytes(tx)
+	return rlp.EncodeToBytesCtx(ctx, tx)
 }
 
 // GetTransactionReceipt returns the transaction receipt for the given transaction hash.
@@ -1326,7 +1326,7 @@ func (s *PublicTransactionPoolAPI) SignTransaction(ctx context.Context, args Sen
 	if err != nil {
 		return nil, err
 	}
-	data, err := rlp.EncodeToBytes(tx)
+	data, err := rlp.EncodeToBytesCtx(ctx, tx)
 	if err != nil {
 		return nil, err
 	}
@@ -1416,7 +1416,7 @@ func (api *PublicDebugAPI) GetBlockRlp(ctx context.Context, number uint64) (stri
 	if block == nil {
 		return "", fmt.Errorf("block #%d not found", number)
 	}
-	encoded, err := rlp.EncodeToBytes(block)
+	encoded, err := rlp.EncodeToBytesCtx(ctx, block)
 	if err != nil {
 		return "", err
 	}

--- a/les/handler.go
+++ b/les/handler.go
@@ -684,7 +684,7 @@ func (pm *ProtocolManager) handleMsg(ctx context.Context, p *peer) error {
 				}
 			}
 			// If known, encode and queue for response packet
-			if encoded, err := rlp.EncodeToBytes(results); err != nil {
+			if encoded, err := rlp.EncodeToBytesCtx(ctx, results); err != nil {
 				log.Error("Failed to encode receipt", "err", err)
 			} else {
 				receipts = append(receipts, encoded)

--- a/light/odr_util.go
+++ b/light/odr_util.go
@@ -101,7 +101,7 @@ func GetBody(ctx context.Context, odr OdrBackend, hash common.Hash, number uint6
 		return nil, err
 	}
 	body := new(types.Body)
-	if err := rlp.Decode(bytes.NewReader(data), body); err != nil {
+	if err := rlp.DecodeCtx(ctx, bytes.NewReader(data), body); err != nil {
 		return nil, err
 	}
 	return body, nil

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -426,7 +426,7 @@ func (self *TxPool) Add(ctx context.Context, tx *types.Transaction) error {
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
-	data, err := rlp.EncodeToBytes(tx)
+	data, err := rlp.EncodeToBytesCtx(ctx, tx)
 	if err != nil {
 		return err
 	}

--- a/netstats/netstats.go
+++ b/netstats/netstats.go
@@ -608,7 +608,7 @@ func (s *Service) assembleBlockStats(ctx context.Context, block *types.Block) *b
 		txs = []txStats{}
 	}
 	// Assemble and return the block stats
-	author, _ := s.engine.Author(header)
+	author, _ := s.engine.Author(ctx, header)
 
 	return &blockStats{
 		Number:     header.Number,

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -154,7 +154,7 @@ func SendCtx(ctx context.Context, w MsgWriter, msgcode uint64, data interface{})
 	ctx, span := trace.StartSpan(ctx, "Send")
 	defer span.End()
 
-	size, r, err := rlp.EncodeToReader(data)
+	size, r, err := rlp.EncodeToReaderCtx(ctx, data)
 	if err != nil {
 		return err
 	}

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -628,7 +628,7 @@ func (rw *rlpxFrameRW) WriteMsg(ctx context.Context, msg Msg) error {
 	ctx, span := trace.StartSpan(ctx, "rlpxFrameRW.WriteMsg")
 	defer span.End()
 
-	ptype, _ := rlp.EncodeToBytes(msg.Code)
+	ptype, _ := rlp.EncodeToBytesCtx(ctx, msg.Code)
 
 	// if snappy is enabled, compress message now
 	if rw.snappy {


### PR DESCRIPTION
This PR adds tracing to rlp encoding and decoding. Context isn't wired into the full stack everywhere, but every call at least gets a `context.Background()`.