### PR TITLE
circleci: add manually triggered branch docker image build/push job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,33 @@ jobs:
               ./release.sh
             fi
 
+  docker:
+    <<: *defaults
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - attach_workspace:
+          at: .
+      - run:
+          name: Store Service Account
+          command: echo $ACCT_AUTH > ${HOME}/gcloud-service-key.json
+      - run:
+          name: install dependencies
+          command: |
+            wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-204.0.0-linux-x86_64.tar.gz --directory-prefix=tmp
+            tar -xvzf tmp/google-cloud-sdk-204.0.0-linux-x86_64.tar.gz -C tmp
+            ./tmp/google-cloud-sdk/install.sh -q
+      - deploy:
+          command: |
+            echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
+            docker build . -t gochain/gochain:${CIRCLE_BRANCH}
+            docker push gochain/gochain:${CIRCLE_BRANCH}
+            echo $ACCT_AUTH > ${HOME}/gcloud-service-key.json
+            ./tmp/google-cloud-sdk/bin/gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
+            docker login -u _json_key -p "$(cat ${HOME}/gcloud-service-key.json)" https://gcr.io
+            docker tag gochain/gochain:${CIRCLE_BRANCH} gcr.io/gochain-core/gochain:${CIRCLE_BRANCH}
+            docker push gcr.io/gochain-core/gochain:${CIRCLE_BRANCH}
+
 workflows:
   version: 2
   prepare-accept-deploy:
@@ -179,3 +206,22 @@ workflows:
             - test
             - test-fuse
             - race
+
+      - approve-docker:
+          type: approval
+          filters:
+            branches:
+              ignore:
+              - master
+              - stable
+              - testnet
+              - latest
+          requires:
+            - test
+            - build
+            - test-fuse
+            - race
+
+      - docker:
+          requires:
+            - approve-docker


### PR DESCRIPTION
This PR adds support for building and pushing docker images for branches, after manual approval. Images are pushed to docker hub and gcr.
![screenshot from 2018-09-17 23-06-22](https://user-images.githubusercontent.com/1194128/45663986-fe765f80-bace-11e8-8d30-57085c04b783.png)
![screenshot from 2018-09-17 23-06-26](https://user-images.githubusercontent.com/1194128/45663988-00d8b980-bacf-11e8-9713-05f4bdcffd3d.png)
![screenshot from 2018-09-17 23-06-33](https://user-images.githubusercontent.com/1194128/45663990-0209e680-bacf-11e8-9f61-2d7097ed41cd.png)
