### PR TITLE
core, miner: log parent hash

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1255,7 +1255,7 @@ func (bc *BlockChain) insertChain(ctx context.Context, chain types.Blocks) (int,
 		switch status {
 		case CanonStatTy:
 			log.Info("Inserted new block", "number", block.Number(), "hash", block.Hash(), "diff", block.Difficulty(),
-				"txs", len(block.Transactions()), "gas", block.GasUsed(), "elapsed", common.PrettyDuration(time.Since(bstart)))
+				"txs", len(block.Transactions()), "parent", block.ParentHash(), "gas", block.GasUsed(), "elapsed", common.PrettyDuration(time.Since(bstart)))
 
 			coalescedLogs = append(coalescedLogs, logs...)
 			blockInsertTimer.UpdateSince(bstart)
@@ -1267,7 +1267,7 @@ func (bc *BlockChain) insertChain(ctx context.Context, chain types.Blocks) (int,
 
 		case SideStatTy:
 			log.Info("Inserted forked block", "number", block.Number(), "hash", block.Hash(), "diff", block.Difficulty(),
-				"txs", len(block.Transactions()), "gas", block.GasUsed(), "elapsed", common.PrettyDuration(time.Since(bstart)))
+				"txs", len(block.Transactions()), "parent", block.ParentHash(), "gas", block.GasUsed(), "elapsed", common.PrettyDuration(time.Since(bstart)))
 
 			blockInsertTimer.UpdateSince(bstart)
 			events = append(events, ChainSideEvent{block})

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -93,7 +93,7 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 	}
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
 	_ = p.engine.Finalize(ctx, p.bc, header, statedb, block.Transactions(), receipts, false)
-	log.Info("Processed Block", "number", header.Number, "hash", header.Hash(), "count", len(txs), "diff", header.Difficulty, "coinbase", header.Coinbase)
+	log.Info("Processed Block", "number", header.Number, "hash", header.Hash(), "count", len(txs), "diff", header.Difficulty, "coinbase", header.Coinbase, "parent", header.ParentHash)
 
 	return receipts, allLogs, *usedGas, nil
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -465,7 +465,7 @@ func (w *worker) commitNewWork(ctx context.Context) {
 	work.Block = w.engine.Finalize(ctx, w.chain, header, work.state, work.txs, work.receipts, true)
 	// We only care about logging if we're actually mining.
 	if atomic.LoadInt32(&w.mining) == 1 {
-		log.Info("Commit new mining work", "number", work.Block.Number(), "diff", work.Block.Difficulty(), "txs", work.tcount, "elapsed", common.PrettyDuration(time.Since(tstart)))
+		log.Info("Commit new mining work", "number", work.Block.Number(), "diff", work.Block.Difficulty(), "txs", work.tcount, "parent", work.Block.ParentHash(), "elapsed", common.PrettyDuration(time.Since(tstart)))
 		w.unconfirmed.Shift(work.Block.NumberU64() - 1)
 	}
 	w.push(work)


### PR DESCRIPTION
This PR adds block parent hashes to some log lines, primarily to better understand what is happening in situations like this:
```
INFO [09-19|16:36:56] Commit new mining work                   number=1424647 diff=4 txs=551   elapsed=160.864ms
INFO [09-19|16:36:57] Commit new mining work                   number=1424647 diff=4 txs=572   elapsed=183.491ms
INFO [09-19|16:36:57] Commit new mining work                   number=1424647 diff=4 txs=582   elapsed=177.180ms
INFO [09-19|16:36:57] Commit new mining work                   number=1424647 diff=4 txs=588   elapsed=189.729ms
INFO [09-19|16:36:57] Commit new mining work                   number=1424647 diff=4 txs=617   elapsed=190.811ms
INFO [09-19|16:36:57] Commit new mining work                   number=1424647 diff=4 txs=628   elapsed=206.916ms
```