### PR TITLE
core: use deterministic same-difficulty tie breaker

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -46,8 +46,6 @@ const (
 	txChanSize = 4096
 	// chainHeadChanSize is the size of channel listening to ChainHeadEvent.
 	chainHeadChanSize = 100
-	// chainSideChanSize is the size of channel listening to ChainSideEvent.
-	chainSideChanSize = 10
 )
 
 // Agent can register themself with the worker


### PR DESCRIPTION
When encountering two chain heads with the same block number and total difficulty, a random one would be chosen as canonical with a 50/50 chance. This could happen if a single node sends out two different versions of a block (with different txs), or it could be two arbitrary length competing branches. In either case, it's not clear who should win (either choice is valid). This PR proposes choosing the block with the most gas used, before falling back to randomization. In the length-1 case, the 'bigger' block is the obvious choice. In the arbitrary length case, the history would have to be inspected to make a more informed choice, but this method is no worse than the old. In both cases, all nodes on the chain will now make the same deterministic choice (when the gas used is different), reducing split decisions.