### PR TITLE
event: don't unsubscribe on feed timeouts

### DIFF
--- a/event/feed.go
+++ b/event/feed.go
@@ -31,7 +31,7 @@ import (
 
 var errBadChannel = errors.New("event: Subscribe argument does not have sendable channel type")
 
-const feedTimeout = 1 * time.Second
+const feedTimeout = 100 * time.Millisecond
 
 // Feed implements one-to-many subscriptions where the carrier of events is a channel.
 // Values sent to a Feed are delivered to all subscribed channels simultaneously.
@@ -205,13 +205,7 @@ func (f *Feed) SendCtx(ctx context.Context, value interface{}) (nsent int) {
 				cases = f.sendCases[:len(cases)-1]
 			}
 		} else if cases[chosen].Chan == timerSelectCase.Chan {
-			// Remove all pending channels from the feed in the event of a timeout.
-			for i := 1; i < len(cases); i++ {
-				if idx := f.sendCases.find(cases[i].Chan.Interface()); idx != -1 {
-					f.sendCases = f.sendCases.delete(idx)
-					log.Warn("feed channel send timeout, subscription dropped", "data", fmt.Sprintf("%T", value))
-				}
-			}
+			log.Trace("Feed channel send timeout, value dropped", "data", fmt.Sprintf("%T", value))
 			break
 		} else {
 			cases = cases.deactivate(chosen)

--- a/event/feed_test.go
+++ b/event/feed_test.go
@@ -275,14 +275,6 @@ func TestFeed_Send_Timeout(t *testing.T) {
 	} else if d := time.Since(t0); d < feedTimeout {
 		t.Fatalf("unexpected delay: %s", d)
 	}
-
-	// Ensure feed no longer exists in subscription.
-	t1 := time.Now()
-	if nsent := feed.Send(100); nsent != 0 {
-		t.Fatal("expected no messages sent")
-	} else if d := time.Since(t1); d > 100*time.Millisecond {
-		t.Fatalf("expected no delay, waited: %s", d)
-	}
 }
 
 func BenchmarkFeedSend1000(b *testing.B) {


### PR DESCRIPTION
In #194 the feed send logic was adjusted to unsubscribe any blocking channels which time out. This is actually a pretty severe penalty for slow receivers, since they may only be blocked temporarily but would be unsubscribed permanently. Instead, we can just drop the value and continue on.