### PR TITLE
core, eth, les, light: simplify event feeds

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -79,7 +79,7 @@ func NewSimulatedBackend(alloc core.GenesisAlloc) *SimulatedBackend {
 		database:   database,
 		blockchain: blockchain,
 		config:     genesis.Config,
-		events:     filters.NewEventSystem(new(event.TypeMux), &filterBackend{database, blockchain}, false),
+		events:     filters.NewEventSystem(new(event.TypeMux), newFilterBackend(database, blockchain), false),
 	}
 	backend.rollback()
 	return backend
@@ -338,7 +338,7 @@ func (b *SimulatedBackend) FilterLogs(ctx context.Context, query gochain.FilterQ
 		to = query.ToBlock.Int64()
 	}
 	// Construct and execute the filter
-	filter := filters.New(&filterBackend{b.database, b.blockchain}, from, to, query.Addresses, query.Topics)
+	filter := filters.New(newFilterBackend(b.database, b.blockchain), from, to, query.Addresses, query.Topics)
 
 	logs, err := filter.Logs(ctx)
 	if err != nil {
@@ -404,6 +404,13 @@ func (m callmsg) Data() []byte         { return m.CallMsg.Data }
 type filterBackend struct {
 	db ethdb.Database
 	bc *core.BlockChain
+
+	txSubsMu sync.Mutex
+	txSubs   map[chan<- core.NewTxsEvent]event.Subscription
+}
+
+func newFilterBackend(db ethdb.Database, bc *core.BlockChain) *filterBackend {
+	return &filterBackend{db: db, bc: bc, txSubs: make(map[chan<- core.NewTxsEvent]event.Subscription)}
 }
 
 func (fb *filterBackend) ChainDb() ethdb.Database  { return fb.db }
@@ -419,20 +426,50 @@ func (fb *filterBackend) GetReceipts(ctx context.Context, hash common.Hash) (typ
 	return core.GetBlockReceipts(fb.db, hash, core.GetBlockNumber(fb.db, hash)), nil
 }
 
-func (fb *filterBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Subscription {
-	return event.NewSubscription(func(quit <-chan struct{}) error {
+func (fb *filterBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) {
+	sub := event.NewSubscription(func(quit <-chan struct{}) error {
 		<-quit
 		return nil
 	})
+	fb.txSubsMu.Lock()
+	fb.txSubs[ch] = sub
+	fb.txSubsMu.Unlock()
 }
-func (fb *filterBackend) SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription {
-	return fb.bc.SubscribeChainEvent(ch)
+
+func (fb *filterBackend) UnsubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) {
+	fb.txSubsMu.Lock()
+	sub, ok := fb.txSubs[ch]
+	if ok {
+		delete(fb.txSubs, ch)
+	}
+	fb.txSubsMu.Unlock()
+	if ok {
+		sub.Unsubscribe()
+	}
 }
-func (fb *filterBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription {
-	return fb.bc.SubscribeRemovedLogsEvent(ch)
+
+func (fb *filterBackend) SubscribeChainEvent(ch chan<- core.ChainEvent) {
+	fb.bc.SubscribeChainEvent(ch)
 }
-func (fb *filterBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription {
-	return fb.bc.SubscribeLogsEvent(ch)
+
+func (fb *filterBackend) UnsubscribeChainEvent(ch chan<- core.ChainEvent) {
+	fb.bc.UnsubscribeChainEvent(ch)
+}
+
+func (fb *filterBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) {
+	fb.bc.SubscribeRemovedLogsEvent(ch)
+}
+
+func (fb *filterBackend) UnsubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) {
+	fb.bc.UnsubscribeRemovedLogsEvent(ch)
+}
+
+func (fb *filterBackend) SubscribeLogsEvent(ch chan<- []*types.Log) {
+	fb.bc.SubscribeLogsEvent(ch)
+}
+
+func (fb *filterBackend) UnsubscribeLogsEvent(ch chan<- []*types.Log) {
+	fb.bc.UnsubscribeLogsEvent(ch)
 }
 
 func (fb *filterBackend) BloomStatus() (uint64, uint64) { return 4096, 0 }

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -40,7 +40,7 @@ import (
 
 // newTestBlockChain creates a blockchain without validation.
 // genesis can be nil to use default
-func newTestBlockChainWithGenesis(ctx context.Context, fakeBool, disk bool, genesis *Genesis) (*BlockChain, error) {
+func newTestBlockChainWithGenesis(fakeBool, disk bool, genesis *Genesis) (*BlockChain, error) {
 	var err error
 	var db ethdb.Database
 	if disk {
@@ -957,7 +957,7 @@ func TestLogReorgs(t *testing.T) {
 	blockchain, _ := NewBlockChain(db, nil, gspec.Config, engine, vm.Config{})
 	defer blockchain.Stop()
 
-	rmLogsCh := make(chan RemovedLogsEvent)
+	rmLogsCh := make(chan RemovedLogsEvent, 1)
 	blockchain.SubscribeRemovedLogsEvent(rmLogsCh)
 	chain, _ := GenerateChain(ctx, params.TestChainConfig, genesis, engine, db, 2, func(ctx context.Context, i int, gen *BlockGen) {
 		if i == 1 {

--- a/core/events.go
+++ b/core/events.go
@@ -17,8 +17,11 @@
 package core
 
 import (
+	"sync"
+
 	"github.com/gochain-io/gochain/common"
 	"github.com/gochain-io/gochain/core/types"
+	"github.com/gochain-io/gochain/log"
 )
 
 // NewTxsEvent is posted when a batch of transactions enter the transaction pool.
@@ -49,3 +52,318 @@ type ChainSideEvent struct {
 }
 
 type ChainHeadEvent struct{ Block *types.Block }
+
+type NewTxsFeed struct {
+	sync.RWMutex
+	subs []chan<- NewTxsEvent
+}
+
+func (f *NewTxsFeed) Close() {
+	f.Lock()
+	for _, sub := range f.subs {
+		close(sub)
+	}
+	f.subs = nil
+	f.Unlock()
+}
+
+func (f *NewTxsFeed) Subscribe(ch chan<- NewTxsEvent) {
+	f.Lock()
+	f.subs = append(f.subs, ch)
+	f.Unlock()
+}
+
+func (f *NewTxsFeed) Unsubscribe(ch chan<- NewTxsEvent) {
+	f.Lock()
+	for i, s := range f.subs {
+		if s == ch {
+			f.subs = append(f.subs[:i], f.subs[i+1:]...)
+			close(ch)
+			break
+		}
+	}
+	f.Unlock()
+}
+
+func (f *NewTxsFeed) Send(ev NewTxsEvent) {
+	f.RLock()
+	for _, sub := range f.subs {
+		select {
+		case sub <- ev:
+		default:
+			log.Trace("NewTxsFeed send dropped: channel full", "txs", len(ev.Txs))
+		}
+	}
+	f.RUnlock()
+}
+
+type ChainFeed struct {
+	sync.RWMutex
+	subs []chan<- ChainEvent
+}
+
+func (f *ChainFeed) Close() {
+	f.Lock()
+	for _, sub := range f.subs {
+		close(sub)
+	}
+	f.subs = nil
+	f.Unlock()
+}
+
+func (f *ChainFeed) Subscribe(ch chan<- ChainEvent) {
+	f.Lock()
+	f.subs = append(f.subs, ch)
+	f.Unlock()
+}
+
+func (f *ChainFeed) Unsubscribe(ch chan<- ChainEvent) {
+	f.Lock()
+	for i, s := range f.subs {
+		if s == ch {
+			f.subs = append(f.subs[:i], f.subs[i+1:]...)
+			close(ch)
+			break
+		}
+	}
+	f.Unlock()
+}
+
+func (f *ChainFeed) Send(ev ChainEvent) {
+	f.RLock()
+	for _, sub := range f.subs {
+		select {
+		case sub <- ev:
+		default:
+			log.Info("ChainFeed send dropped: channel full", "block", ev.Block.NumberU64(), "hash", ev.Hash)
+		}
+	}
+	f.RUnlock()
+}
+
+type ChainHeadFeed struct {
+	sync.RWMutex
+	subs []chan<- ChainHeadEvent
+}
+
+func (f *ChainHeadFeed) Close() {
+	f.Lock()
+	for _, sub := range f.subs {
+		close(sub)
+	}
+	f.subs = nil
+	f.Unlock()
+}
+
+func (f *ChainHeadFeed) Subscribe(ch chan<- ChainHeadEvent) {
+	f.Lock()
+	f.subs = append(f.subs, ch)
+	f.Unlock()
+}
+
+func (f *ChainHeadFeed) Unsubscribe(ch chan<- ChainHeadEvent) {
+	f.Lock()
+	for i, s := range f.subs {
+		if s == ch {
+			f.subs = append(f.subs[:i], f.subs[i+1:]...)
+			close(ch)
+			break
+		}
+	}
+	f.Unlock()
+}
+
+func (f *ChainHeadFeed) Send(ev ChainHeadEvent) {
+	f.RLock()
+	for _, sub := range f.subs {
+		select {
+		case sub <- ev:
+		default:
+			log.Info("ChainHeadFeed send dropped: channel full", "block", ev.Block.NumberU64(), "hash", ev.Block.Hash())
+		}
+	}
+	f.RUnlock()
+}
+
+type ChainSideFeed struct {
+	sync.RWMutex
+	subs []chan<- ChainSideEvent
+}
+
+func (f *ChainSideFeed) Close() {
+	f.Lock()
+	for _, sub := range f.subs {
+		close(sub)
+	}
+	f.subs = nil
+	f.Unlock()
+}
+
+func (f *ChainSideFeed) Subscribe(ch chan<- ChainSideEvent) {
+	f.Lock()
+	f.subs = append(f.subs, ch)
+	f.Unlock()
+}
+
+func (f *ChainSideFeed) Unsubscribe(ch chan<- ChainSideEvent) {
+	f.Lock()
+	for i, s := range f.subs {
+		if s == ch {
+			f.subs = append(f.subs[:i], f.subs[i+1:]...)
+			close(ch)
+			break
+		}
+	}
+	f.Unlock()
+}
+
+func (f *ChainSideFeed) Send(ev ChainSideEvent) {
+	f.RLock()
+	for _, sub := range f.subs {
+		select {
+		case sub <- ev:
+		default:
+			log.Info("ChainSideFeed send dropped: channel full", "block", ev.Block.NumberU64(), "hash", ev.Block.Hash())
+		}
+	}
+	f.RUnlock()
+}
+
+type PendingLogsFeed struct {
+	sync.RWMutex
+	subs []chan<- PendingLogsEvent
+}
+
+func (f *PendingLogsFeed) Close() {
+	f.Lock()
+	for _, sub := range f.subs {
+		close(sub)
+	}
+	f.subs = nil
+	f.Unlock()
+}
+
+func (f *PendingLogsFeed) Subscribe(ch chan<- PendingLogsEvent) {
+	f.Lock()
+	f.subs = append(f.subs, ch)
+	f.Unlock()
+}
+
+func (f *PendingLogsFeed) Unsubscribe(ch chan<- PendingLogsEvent) {
+	f.Lock()
+	for i, s := range f.subs {
+		if s == ch {
+			f.subs = append(f.subs[:i], f.subs[i+1:]...)
+			close(ch)
+			break
+		}
+	}
+	f.Unlock()
+}
+
+func (f *PendingLogsFeed) Send(ev PendingLogsEvent) {
+	f.RLock()
+	for _, sub := range f.subs {
+		select {
+		case sub <- ev:
+		default:
+			log.Info("PendingLogsFeed send dropped: channel full", "len", len(ev.Logs))
+		}
+	}
+	f.RUnlock()
+}
+
+type RemovedLogsFeed struct {
+	sync.RWMutex
+	subs []chan<- RemovedLogsEvent
+}
+
+func (f *RemovedLogsFeed) Close() {
+	f.Lock()
+	for _, sub := range f.subs {
+		close(sub)
+	}
+	f.subs = nil
+	f.Unlock()
+}
+
+func (f *RemovedLogsFeed) Subscribe(ch chan<- RemovedLogsEvent) {
+	f.Lock()
+	f.subs = append(f.subs, ch)
+	f.Unlock()
+}
+
+func (f *RemovedLogsFeed) Unsubscribe(ch chan<- RemovedLogsEvent) {
+	f.Lock()
+	for i, s := range f.subs {
+		if s == ch {
+			f.subs = append(f.subs[:i], f.subs[i+1:]...)
+			close(ch)
+			break
+		}
+	}
+	f.Unlock()
+}
+
+func (f *RemovedLogsFeed) Send(ev RemovedLogsEvent) {
+	f.RLock()
+	for _, sub := range f.subs {
+		select {
+		case sub <- ev:
+		default:
+			log.Info("RemovedLogsFeed send dropped: channel full", "len", len(ev.Logs))
+		}
+	}
+	f.RUnlock()
+}
+
+type LogsFeed struct {
+	sync.RWMutex
+	subs []chan<- []*types.Log
+}
+
+func (f *LogsFeed) Close() {
+	f.Lock()
+	for _, sub := range f.subs {
+		close(sub)
+	}
+	f.subs = nil
+	f.Unlock()
+}
+
+func (f *LogsFeed) Len() int {
+	f.RLock()
+	n := len(f.subs)
+	f.RUnlock()
+	return n
+}
+
+func (f *LogsFeed) Subscribe(ch chan<- []*types.Log) {
+	f.Lock()
+	f.subs = append(f.subs, ch)
+	f.Unlock()
+}
+
+func (f *LogsFeed) Unsubscribe(ch chan<- []*types.Log) {
+	f.Lock()
+	for i, s := range f.subs {
+		if s == ch {
+			f.subs = append(f.subs[:i], f.subs[i+1:]...)
+			close(ch)
+			break
+		}
+	}
+	f.Unlock()
+}
+
+func (f *LogsFeed) Send(logs []*types.Log) {
+	f.RLock()
+	for _, sub := range f.subs {
+		select {
+		case sub <- logs:
+		default:
+			log.Info("LogsFeed send dropped: channel full", "len", len(logs))
+		}
+	}
+	f.RUnlock()
+}

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -39,7 +39,7 @@ func benchmarkStateProcessor_Process(cnt int) func(b *testing.B) {
 		tx, _ = types.SignTx(tx, signer, key)
 		txs[i] = tx
 	}
-	bc, err := newTestBlockChainWithGenesis(ctx, false, true, genesis)
+	bc, err := newTestBlockChainWithGenesis(false, true, genesis)
 	block := types.NewBlock(&types.Header{
 		GasLimit: bc.GasLimit(),
 	}, txs, nil, nil)
@@ -69,7 +69,6 @@ func benchmarkStateProcessor_Process(cnt int) func(b *testing.B) {
 }
 
 func TestStateProcessor(t *testing.T) {
-
 	numTxs := 10000
 
 	ctx := context.Background()
@@ -85,7 +84,7 @@ func TestStateProcessor(t *testing.T) {
 	}
 	signer := types.NewEIP155Signer(genesis.Config.ChainId)
 
-	bc, err := newTestBlockChainWithGenesis(ctx, false, true, genesis)
+	bc, err := newTestBlockChainWithGenesis(false, true, genesis)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -166,24 +166,44 @@ func (b *EthApiBackend) GetEVM(ctx context.Context, msg core.Message, state *sta
 	return vm.NewEVM(context, state, b.eth.chainConfig, vmCfg), nil
 }
 
-func (b *EthApiBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription {
-	return b.eth.BlockChain().SubscribeRemovedLogsEvent(ch)
+func (b *EthApiBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) {
+	b.eth.BlockChain().SubscribeRemovedLogsEvent(ch)
 }
 
-func (b *EthApiBackend) SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription {
-	return b.eth.BlockChain().SubscribeChainEvent(ch)
+func (b *EthApiBackend) UnsubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) {
+	b.eth.BlockChain().UnsubscribeRemovedLogsEvent(ch)
 }
 
-func (b *EthApiBackend) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription {
-	return b.eth.BlockChain().SubscribeChainHeadEvent(ch)
+func (b *EthApiBackend) SubscribeChainEvent(ch chan<- core.ChainEvent) {
+	b.eth.BlockChain().SubscribeChainEvent(ch)
 }
 
-func (b *EthApiBackend) SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) event.Subscription {
-	return b.eth.BlockChain().SubscribeChainSideEvent(ch)
+func (b *EthApiBackend) UnsubscribeChainEvent(ch chan<- core.ChainEvent) {
+	b.eth.BlockChain().UnsubscribeChainEvent(ch)
 }
 
-func (b *EthApiBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription {
-	return b.eth.BlockChain().SubscribeLogsEvent(ch)
+func (b *EthApiBackend) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) {
+	b.eth.BlockChain().SubscribeChainHeadEvent(ch)
+}
+
+func (b *EthApiBackend) UnsubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) {
+	b.eth.BlockChain().UnsubscribeChainHeadEvent(ch)
+}
+
+func (b *EthApiBackend) SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) {
+	b.eth.BlockChain().SubscribeChainSideEvent(ch)
+}
+
+func (b *EthApiBackend) UnsubscribeChainSideEvent(ch chan<- core.ChainSideEvent) {
+	b.eth.BlockChain().UnsubscribeChainSideEvent(ch)
+}
+
+func (b *EthApiBackend) SubscribeLogsEvent(ch chan<- []*types.Log) {
+	b.eth.BlockChain().SubscribeLogsEvent(ch)
+}
+
+func (b *EthApiBackend) UnsubscribeLogsEvent(ch chan<- []*types.Log) {
+	b.eth.BlockChain().UnsubscribeLogsEvent(ch)
 }
 
 func (b *EthApiBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
@@ -215,8 +235,12 @@ func (b *EthApiBackend) TxPoolContent(ctx context.Context) (map[common.Address]t
 	return b.eth.TxPool().Content(ctx)
 }
 
-func (b *EthApiBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Subscription {
-	return b.eth.TxPool().SubscribeNewTxsEvent(ch)
+func (b *EthApiBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) {
+	b.eth.TxPool().SubscribeNewTxsEvent(ch)
+}
+
+func (b *EthApiBackend) UnsubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) {
+	b.eth.TxPool().UnsubscribeNewTxsEvent(ch)
 }
 
 func (b *EthApiBackend) Downloader() *downloader.Downloader {

--- a/eth/filters/bench_test.go
+++ b/eth/filters/bench_test.go
@@ -130,7 +130,7 @@ func benchmarkBloomBits(b *testing.B, sectionSize uint64) {
 		if i%20 == 0 {
 			db.Close()
 			db, _ = ethdb.NewLDBDatabase(benchDataDir, 128, 1024)
-			backend = &testBackend{mux, db, cnt, new(event.Feed), new(event.Feed), new(event.Feed), new(event.Feed)}
+			backend = &testBackend{mux: mux, db: db, sections: cnt}
 		}
 		var addr common.Address
 		addr[0] = byte(i)
@@ -191,7 +191,7 @@ func BenchmarkNoBloomBits(b *testing.B) {
 	fmt.Println("Running filter benchmarks...")
 	start := time.Now()
 	mux := new(event.TypeMux)
-	backend := &testBackend{mux, db, 0, new(event.Feed), new(event.Feed), new(event.Feed), new(event.Feed)}
+	backend := &testBackend{mux: mux, db: db}
 	filter := New(backend, 0, int64(headNum), []common.Address{{}}, nil)
 	filter.Logs(context.Background())
 	d := time.Since(start)

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -35,10 +35,14 @@ type Backend interface {
 	HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Header, error)
 	GetReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error)
 
-	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
-	SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription
-	SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription
-	SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription
+	SubscribeNewTxsEvent(chan<- core.NewTxsEvent)
+	UnsubscribeNewTxsEvent(chan<- core.NewTxsEvent)
+	SubscribeChainEvent(ch chan<- core.ChainEvent)
+	UnsubscribeChainEvent(ch chan<- core.ChainEvent)
+	SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent)
+	UnsubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent)
+	SubscribeLogsEvent(ch chan<- []*types.Log)
+	UnsubscribeLogsEvent(ch chan<- []*types.Log)
 
 	BloomStatus() (uint64, uint64)
 	ServiceFilter(ctx context.Context, session *bloombits.MatcherSession)

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -51,18 +51,14 @@ func BenchmarkFilters(b *testing.B) {
 	defer os.RemoveAll(dir)
 
 	var (
-		db, _      = ethdb.NewLDBDatabase(dir, 0, 0)
-		mux        = new(event.TypeMux)
-		txFeed     = new(event.Feed)
-		rmLogsFeed = new(event.Feed)
-		logsFeed   = new(event.Feed)
-		chainFeed  = new(event.Feed)
-		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed}
-		key1, _    = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
-		addr1      = crypto.PubkeyToAddress(key1.PublicKey)
-		addr2      = common.BytesToAddress([]byte("jeff"))
-		addr3      = common.BytesToAddress([]byte("ethereum"))
-		addr4      = common.BytesToAddress([]byte("random addresses please"))
+		db, _   = ethdb.NewLDBDatabase(dir, 0, 0)
+		mux     = new(event.TypeMux)
+		backend = &testBackend{mux: mux, db: db}
+		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		addr1   = crypto.PubkeyToAddress(key1.PublicKey)
+		addr2   = common.BytesToAddress([]byte("jeff"))
+		addr3   = common.BytesToAddress([]byte("ethereum"))
+		addr4   = common.BytesToAddress([]byte("random addresses please"))
 	)
 	defer db.Close()
 
@@ -117,15 +113,11 @@ func TestFilters(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	var (
-		db, _      = ethdb.NewLDBDatabase(dir, 0, 0)
-		mux        = new(event.TypeMux)
-		txFeed     = new(event.Feed)
-		rmLogsFeed = new(event.Feed)
-		logsFeed   = new(event.Feed)
-		chainFeed  = new(event.Feed)
-		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed}
-		key1, _    = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
-		addr       = crypto.PubkeyToAddress(key1.PublicKey)
+		db, _   = ethdb.NewLDBDatabase(dir, 0, 0)
+		mux     = new(event.TypeMux)
+		backend = &testBackend{mux: mux, db: db}
+		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		addr    = crypto.PubkeyToAddress(key1.PublicKey)
 
 		hash1 = common.BytesToHash([]byte("topic1"))
 		hash2 = common.BytesToHash([]byte("topic2"))

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -91,7 +91,7 @@ func newTestProtocolManagerMust(ctx context.Context, t *testing.T, mode download
 
 // testTxPool is a fake, helper transaction pool for testing purposes
 type testTxPool struct {
-	txFeed event.Feed
+	txFeed core.NewTxsFeed
 	pool   []*types.Transaction        // Collection of all transactions
 	added  chan<- []*types.Transaction // Notification channel for new transactions
 
@@ -135,8 +135,12 @@ func (p *testTxPool) PendingList(ctx context.Context) types.Transactions {
 	return pending
 }
 
-func (p *testTxPool) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Subscription {
-	return p.txFeed.Subscribe(ch)
+func (p *testTxPool) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) {
+	p.txFeed.Subscribe(ch)
+}
+
+func (p *testTxPool) UnsubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) {
+	p.txFeed.Unsubscribe(ch)
 }
 
 // newTestTransaction create a new dummy transaction.

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gochain-io/gochain/common"
 	"github.com/gochain-io/gochain/core"
 	"github.com/gochain-io/gochain/core/types"
-	"github.com/gochain-io/gochain/event"
 	"github.com/gochain-io/gochain/rlp"
 )
 
@@ -111,7 +110,8 @@ type txPool interface {
 
 	// SubscribeNewTxsEvent should return an event subscription of
 	// NewTxsEvent and send events to the given channel.
-	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
+	SubscribeNewTxsEvent(chan<- core.NewTxsEvent)
+	UnsubscribeNewTxsEvent(chan<- core.NewTxsEvent)
 }
 
 // statusData is the network packet for the status message.

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -56,9 +56,12 @@ type Backend interface {
 	GetReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error)
 	GetTd(blockHash common.Hash) *big.Int
 	GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header, vmCfg vm.Config) (*vm.EVM, error)
-	SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription
-	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription
-	SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) event.Subscription
+	SubscribeChainEvent(ch chan<- core.ChainEvent)
+	UnsubscribeChainEvent(ch chan<- core.ChainEvent)
+	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent)
+	UnsubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent)
+	SubscribeChainSideEvent(ch chan<- core.ChainSideEvent)
+	UnsubscribeChainSideEvent(ch chan<- core.ChainSideEvent)
 
 	// TxPool API
 	SendTx(ctx context.Context, signedTx *types.Transaction) error
@@ -67,7 +70,8 @@ type Backend interface {
 	GetPoolNonce(ctx context.Context, addr common.Address) (uint64, error)
 	Stats() (pending int, queued int)
 	TxPoolContent(context.Context) (map[common.Address]types.Transactions, map[common.Address]types.Transactions)
-	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
+	SubscribeNewTxsEvent(chan<- core.NewTxsEvent)
+	UnsubscribeNewTxsEvent(chan<- core.NewTxsEvent)
 
 	ChainConfig() *params.ChainConfig
 	CurrentBlock() *types.Block

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -145,29 +145,45 @@ func (b *LesApiBackend) TxPoolContent(ctx context.Context) (map[common.Address]t
 	return b.eth.txPool.Content(ctx)
 }
 
-func (b *LesApiBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Subscription {
-	return b.eth.txPool.SubscribeNewTxsEvent(ch)
+func (b *LesApiBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) {
+	b.eth.txPool.SubscribeNewTxsEvent(ch)
 }
 
-func (b *LesApiBackend) SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription {
-	return b.eth.blockchain.SubscribeChainEvent(ch)
+func (b *LesApiBackend) UnsubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) {
+	b.eth.txPool.UnsubscribeNewTxsEvent(ch)
 }
 
-func (b *LesApiBackend) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription {
-	return b.eth.blockchain.SubscribeChainHeadEvent(ch)
+func (b *LesApiBackend) SubscribeChainEvent(ch chan<- core.ChainEvent) {
+	b.eth.blockchain.SubscribeChainEvent(ch)
 }
 
-func (b *LesApiBackend) SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) event.Subscription {
-	return b.eth.blockchain.SubscribeChainSideEvent(ch)
+func (b *LesApiBackend) UnsubscribeChainEvent(ch chan<- core.ChainEvent) {
+	b.eth.blockchain.UnsubscribeChainEvent(ch)
 }
 
-func (b *LesApiBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription {
-	return b.eth.blockchain.SubscribeLogsEvent(ch)
+func (b *LesApiBackend) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) {
+	b.eth.blockchain.SubscribeChainHeadEvent(ch)
 }
 
-func (b *LesApiBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription {
-	return b.eth.blockchain.SubscribeRemovedLogsEvent(ch)
+func (b *LesApiBackend) UnsubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) {
+	b.eth.blockchain.UnsubscribeChainHeadEvent(ch)
 }
+
+func (b *LesApiBackend) SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) {
+	b.eth.blockchain.SubscribeChainSideEvent(ch)
+}
+
+func (b *LesApiBackend) UnsubscribeChainSideEvent(ch chan<- core.ChainSideEvent) {
+	b.eth.blockchain.UnsubscribeChainSideEvent(ch)
+}
+
+func (b *LesApiBackend) SubscribeLogsEvent(ch chan<- []*types.Log) {}
+
+func (b *LesApiBackend) UnsubscribeLogsEvent(ch chan<- []*types.Log) {}
+
+func (b *LesApiBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) {}
+
+func (b *LesApiBackend) UnsubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) {}
 
 func (b *LesApiBackend) Downloader() *downloader.Downloader {
 	return b.eth.Downloader()

--- a/les/backend.go
+++ b/les/backend.go
@@ -141,7 +141,7 @@ func New(ctx context.Context, sctx *node.ServiceContext, config *eth.Config) (*L
 	}
 
 	leth.txPool = light.NewTxPool(leth.chainConfig, leth.blockchain, leth.relay)
-	if leth.protocolManager, err = NewProtocolManager(ctx, leth.chainConfig, true, ClientProtocolVersions, config.NetworkId, leth.eventMux, leth.engine, leth.peers, leth.blockchain, nil, chainDb, leth.odr, leth.relay, quitSync, &leth.wg); err != nil {
+	if leth.protocolManager, err = NewProtocolManager(ctx, leth.chainConfig, true, ClientProtocolVersions, config.NetworkId, leth.eventMux, leth.peers, leth.blockchain, nil, chainDb, leth.odr, leth.relay, quitSync, &leth.wg); err != nil {
 		return nil, err
 	}
 	leth.ApiBackend = &LesApiBackend{

--- a/les/handler.go
+++ b/les/handler.go
@@ -31,7 +31,6 @@ import (
 	"go.opencensus.io/trace"
 
 	"github.com/gochain-io/gochain/common"
-	"github.com/gochain-io/gochain/consensus"
 	"github.com/gochain-io/gochain/core"
 	"github.com/gochain-io/gochain/core/state"
 	"github.com/gochain-io/gochain/core/types"
@@ -87,7 +86,8 @@ type BlockChain interface {
 	GetHeaderByNumber(number uint64) *types.Header
 	GetAncestor(hash common.Hash, number, ancestor uint64, maxNonCanonical *uint64) (common.Hash, uint64)
 	Genesis() *types.Block
-	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription
+	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent)
+	UnsubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent)
 }
 
 type txPool interface {
@@ -131,7 +131,7 @@ type ProtocolManager struct {
 
 // NewProtocolManager returns a new ethereum sub protocol manager. The Ethereum sub protocol manages peers capable
 // with the ethereum network.
-func NewProtocolManager(ctx context.Context, chainConfig *params.ChainConfig, lightSync bool, protocolVersions []uint, networkId uint64, mux *event.TypeMux, engine consensus.Engine, peers *peerSet, blockchain BlockChain, txpool txPool, chainDb ethdb.Database, odr *LesOdr, txrelay *LesTxRelay, quitSync chan struct{}, wg *sync.WaitGroup) (*ProtocolManager, error) {
+func NewProtocolManager(ctx context.Context, chainConfig *params.ChainConfig, lightSync bool, protocolVersions []uint, networkId uint64, mux *event.TypeMux, peers *peerSet, blockchain BlockChain, txpool txPool, chainDb ethdb.Database, odr *LesOdr, txrelay *LesTxRelay, quitSync chan struct{}, wg *sync.WaitGroup) (*ProtocolManager, error) {
 	// Create the protocol manager with the base fields
 	manager := &ProtocolManager{
 		lightSync:   lightSync,

--- a/les/helper_test.go
+++ b/les/helper_test.go
@@ -181,7 +181,7 @@ func newTestProtocolManager(ctx context.Context, lightSync bool, blocks int, gen
 	} else {
 		protocolVersions = ServerProtocolVersions
 	}
-	pm, err := NewProtocolManager(ctx, gspec.Config, lightSync, protocolVersions, NetworkId, evmux, engine, peers, chain, nil, db, odr, nil, make(chan struct{}), new(sync.WaitGroup))
+	pm, err := NewProtocolManager(ctx, gspec.Config, lightSync, protocolVersions, NetworkId, evmux, peers, chain, nil, db, odr, nil, make(chan struct{}), new(sync.WaitGroup))
 	if err != nil {
 		return nil, err
 	}

--- a/les/server.go
+++ b/les/server.go
@@ -52,7 +52,7 @@ type LesServer struct {
 
 func NewLesServer(ctx context.Context, eth *eth.GoChain, config *eth.Config) (*LesServer, error) {
 	quitSync := make(chan struct{})
-	pm, err := NewProtocolManager(ctx, eth.BlockChain().Config(), false, ServerProtocolVersions, config.NetworkId, eth.EventMux(), eth.Engine(), newPeerSet(), eth.BlockChain(), eth.TxPool(), eth.ChainDb(), nil, nil, quitSync, new(sync.WaitGroup))
+	pm, err := NewProtocolManager(ctx, eth.BlockChain().Config(), false, ServerProtocolVersions, config.NetworkId, eth.EventMux(), newPeerSet(), eth.BlockChain(), eth.TxPool(), eth.ChainDb(), nil, nil, quitSync, new(sync.WaitGroup))
 	if err != nil {
 		return nil, err
 	}
@@ -322,7 +322,7 @@ func (s *requestCostStats) update(msgCode, reqCnt, cost uint64) {
 func (pm *ProtocolManager) blockLoop() {
 	pm.wg.Add(1)
 	headCh := make(chan core.ChainHeadEvent, 100)
-	headSub := pm.blockchain.SubscribeChainHeadEvent(headCh)
+	pm.blockchain.SubscribeChainHeadEvent(headCh)
 	go func() {
 		var lastHead *types.Header
 		lastBroadcastTd := common.Big0
@@ -378,7 +378,7 @@ func (pm *ProtocolManager) blockLoop() {
 					}
 				}
 			case <-pm.quitSync:
-				headSub.Unsubscribe()
+				pm.blockchain.UnsubscribeChainHeadEvent(headCh)
 				pm.wg.Done()
 				return
 			}


### PR DESCRIPTION
This PR replaces some of event feeds with simpler, type-safe, idiomatic structs. This enabled some related simplifications (less goroutines and timeouts), and better observation via logging of the individual feed subscribers which led to some re-calibration of the buffer sizes.