### PR TITLE
consensus, core, miner: strict block finalization deadline

### DIFF
--- a/consensus/clique/fake.go
+++ b/consensus/clique/fake.go
@@ -111,7 +111,7 @@ func (e *fakeEngine) delayOrFail(_ context.Context, _ consensus.ChainReader, hea
 	return nil
 }
 
-func (e *fakeEngine) Prepare(ctx context.Context, chain consensus.ChainReader, header *types.Header) error {
+func (e *fakeEngine) Prepare(ctx context.Context, chain consensus.ChainReader, header *types.Header) (*time.Time, error) {
 	header.Extra = ExtraEnsureVanity(header.Extra)
 	if header.Difficulty == nil {
 		header.Difficulty = header.Coinbase.Big()
@@ -119,7 +119,7 @@ func (e *fakeEngine) Prepare(ctx context.Context, chain consensus.ChainReader, h
 			header.Difficulty.SetUint64(1)
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 func (e *fakeEngine) Finalize(ctx context.Context, chain consensus.ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction,

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -19,6 +19,7 @@ package consensus
 
 import (
 	"context"
+	"time"
 
 	"github.com/gochain-io/gochain/accounts"
 	"github.com/gochain-io/gochain/common"
@@ -70,7 +71,8 @@ type Engine interface {
 
 	// Prepare initializes the consensus fields of a block header according to the
 	// rules of a particular engine. The changes are executed inline.
-	Prepare(ctx context.Context, chain ChainReader, header *types.Header) error
+	// Returns a deadline for block finalization, if applicable.
+	Prepare(ctx context.Context, chain ChainReader, header *types.Header) (*time.Time, error)
 
 	// Finalize runs any post-transaction state modifications (e.g. block rewards)
 	// and assembles the final block (if block is true).

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -173,7 +173,7 @@ func GenerateChain(ctx context.Context, config *params.ChainConfig, first *types
 		}
 
 		if b.engine != nil {
-			if err := b.engine.Prepare(ctx, b.chainReader, b.header); err != nil {
+			if _, err := b.engine.Prepare(ctx, b.chainReader, b.header); err != nil {
 				panic(fmt.Sprintf("failed to prepare %d: %v", b.header.Number.Uint64(), err))
 			}
 			block := b.engine.Finalize(ctx, b.chainReader, b.header, statedb, b.txs, b.receipts, true)


### PR DESCRIPTION
This PR adds a deadline so that block assembly is short-circuited if the block timestamp passes. This will keep block times closer to the configured period, even if more txs could have been included for a more full block. The block broadcast was also adjusted from sqrt(peers) to all peers.