### PR TITLE
Add SecureTrie hash cache.

### DIFF
--- a/trie/secure_trie_test.go
+++ b/trie/secure_trie_test.go
@@ -117,8 +117,7 @@ func TestSecureTrieConcurrency(t *testing.T) {
 	threads := runtime.NumCPU()
 	tries := make([]*SecureTrie, threads)
 	for i := 0; i < threads; i++ {
-		cpy := *trie
-		tries[i] = &cpy
+		tries[i] = trie.Clone()
 	}
 	// Start a batch of goroutines interactng with the trie
 	pend := new(sync.WaitGroup)


### PR DESCRIPTION
This commit adds a cache inside `trie.SecureTrie` to avoid duplicate calls to `hashKey()`. This saves a significant amount of time during `ApplyTransaction()` as most hashes are duplicates in large blocks.