### PR TITLE
consensus/clique: earlier deadline

### DIFF
--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -614,6 +614,7 @@ func (c *Clique) Prepare(ctx context.Context, chain consensus.ChainReader, heade
 	var deadline *time.Time
 	if c.config.Period != 0 {
 		t := time.Unix(header.Time.Int64(), 0)
+		t = t.Add(-time.Duration(c.config.Period) * time.Second / 2)
 		deadline = &t
 	}
 	return deadline, nil


### PR DESCRIPTION
This PR adjusts the deadline to be more conservative: half the period. By limiting mining to the first half of the period, peers have roughly the same amount of time to process and be prepared for the next block during the second half of the period. 