### PR TITLE
core: make some blockchain fields atomic instead of using whole struct lock

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -100,7 +100,7 @@ func (b *SimulatedBackend) Commit(ctx context.Context) {
 // rollback aborts all pending transactions, reverting to the last committed state.
 func (b *SimulatedBackend) rollback() {
 	ctx := context.TODO()
-	blocks, _ := core.GenerateChain(ctx, b.config, b.blockchain.CurrentBlockCtx(ctx), clique.NewFaker(), b.database, 1, nil)
+	blocks, _ := core.GenerateChain(ctx, b.config, b.blockchain.CurrentBlock(), clique.NewFaker(), b.database, 1, nil)
 	statedb, err := b.blockchain.State()
 	if err != nil {
 		panic(err)
@@ -118,7 +118,7 @@ func (b *SimulatedBackend) CodeAt(ctx context.Context, contract common.Address, 
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if blockNumber != nil && blockNumber.Cmp(b.blockchain.CurrentBlockCtx(ctx).Number()) != 0 {
+	if blockNumber != nil && blockNumber.Cmp(b.blockchain.CurrentBlock().Number()) != 0 {
 		return nil, errBlockNumberUnsupported
 	}
 	statedb, _ := b.blockchain.State()
@@ -130,7 +130,7 @@ func (b *SimulatedBackend) BalanceAt(ctx context.Context, contract common.Addres
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if blockNumber != nil && blockNumber.Cmp(b.blockchain.CurrentBlockCtx(ctx).Number()) != 0 {
+	if blockNumber != nil && blockNumber.Cmp(b.blockchain.CurrentBlock().Number()) != 0 {
 		return nil, errBlockNumberUnsupported
 	}
 	statedb, _ := b.blockchain.State()
@@ -142,7 +142,7 @@ func (b *SimulatedBackend) NonceAt(ctx context.Context, contract common.Address,
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if blockNumber != nil && blockNumber.Cmp(b.blockchain.CurrentBlockCtx(ctx).Number()) != 0 {
+	if blockNumber != nil && blockNumber.Cmp(b.blockchain.CurrentBlock().Number()) != 0 {
 		return 0, errBlockNumberUnsupported
 	}
 	statedb, _ := b.blockchain.State()
@@ -154,7 +154,7 @@ func (b *SimulatedBackend) StorageAt(ctx context.Context, contract common.Addres
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if blockNumber != nil && blockNumber.Cmp(b.blockchain.CurrentBlockCtx(ctx).Number()) != 0 {
+	if blockNumber != nil && blockNumber.Cmp(b.blockchain.CurrentBlock().Number()) != 0 {
 		return nil, errBlockNumberUnsupported
 	}
 	statedb, _ := b.blockchain.State()
@@ -181,14 +181,14 @@ func (b *SimulatedBackend) CallContract(ctx context.Context, call gochain.CallMs
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if blockNumber != nil && blockNumber.Cmp(b.blockchain.CurrentBlockCtx(ctx).Number()) != 0 {
+	if blockNumber != nil && blockNumber.Cmp(b.blockchain.CurrentBlock().Number()) != 0 {
 		return nil, errBlockNumberUnsupported
 	}
 	state, err := b.blockchain.State()
 	if err != nil {
 		return nil, err
 	}
-	rval, _, _, err := b.callContract(ctx, call, b.blockchain.CurrentBlockCtx(ctx), state)
+	rval, _, _, err := b.callContract(ctx, call, b.blockchain.CurrentBlock(), state)
 	return rval, err
 }
 
@@ -310,7 +310,7 @@ func (b *SimulatedBackend) SendTransaction(ctx context.Context, tx *types.Transa
 		panic(fmt.Errorf("invalid transaction nonce: got %d, want %d", tx.Nonce(), nonce))
 	}
 
-	blocks, _ := core.GenerateChain(ctx, b.config, b.blockchain.CurrentBlockCtx(ctx), clique.NewFaker(), b.database, 1, func(ctx context.Context, number int, block *core.BlockGen) {
+	blocks, _ := core.GenerateChain(ctx, b.config, b.blockchain.CurrentBlock(), clique.NewFaker(), b.database, 1, func(ctx context.Context, number int, block *core.BlockGen) {
 		for _, tx := range b.pendingBlock.Transactions() {
 			block.AddTx(ctx, tx)
 		}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -327,9 +327,7 @@ func (pool *TxPool) loop() {
 	defer journal.Stop()
 
 	// Track the current and latest blocks for transaction reorgs.
-	pool.mu.Lock()
 	b := pool.chain.CurrentBlock()
-	pool.mu.Unlock()
 	blocks := struct {
 		sync.RWMutex
 		current, latest *types.Block

--- a/eth/api.go
+++ b/eth/api.go
@@ -295,7 +295,7 @@ func (api *PublicDebugAPI) DumpBlock(ctx context.Context, blockNr rpc.BlockNumbe
 	}
 	var block *types.Block
 	if blockNr == rpc.LatestBlockNumber {
-		block = api.eth.blockchain.CurrentBlockCtx(ctx)
+		block = api.eth.blockchain.CurrentBlock()
 	} else {
 		block = api.eth.blockchain.GetBlockByNumber(uint64(blockNr))
 	}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -85,7 +85,7 @@ func (b *EthApiBackend) HeaderByNumber(ctx context.Context, blockNr rpc.BlockNum
 	}
 	// Otherwise resolve and return the block
 	if blockNr == rpc.LatestBlockNumber {
-		return b.eth.blockchain.CurrentBlockCtx(ctx).Header(), nil
+		return b.eth.blockchain.CurrentBlock().Header(), nil
 	}
 	return b.eth.blockchain.GetHeaderByNumber(uint64(blockNr)), nil
 }
@@ -101,7 +101,7 @@ func (b *EthApiBackend) BlockByNumber(ctx context.Context, blockNr rpc.BlockNumb
 	}
 	// Otherwise resolve and return the block
 	if blockNr == rpc.LatestBlockNumber {
-		return b.eth.blockchain.CurrentBlockCtx(ctx), nil
+		return b.eth.blockchain.CurrentBlock(), nil
 	}
 	return b.eth.blockchain.GetBlockByNumber(uint64(blockNr)), nil
 }

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -99,7 +99,7 @@ func (api *PrivateDebugAPI) TraceChain(ctx context.Context, start, end rpc.Block
 	case rpc.PendingBlockNumber:
 		from = api.eth.miner.PendingBlock(ctx)
 	case rpc.LatestBlockNumber:
-		from = api.eth.blockchain.CurrentBlockCtx(ctx)
+		from = api.eth.blockchain.CurrentBlock()
 	default:
 		from = api.eth.blockchain.GetBlockByNumber(uint64(start))
 	}
@@ -107,7 +107,7 @@ func (api *PrivateDebugAPI) TraceChain(ctx context.Context, start, end rpc.Block
 	case rpc.PendingBlockNumber:
 		to = api.eth.miner.PendingBlock(ctx)
 	case rpc.LatestBlockNumber:
-		to = api.eth.blockchain.CurrentBlockCtx(ctx)
+		to = api.eth.blockchain.CurrentBlock()
 	default:
 		to = api.eth.blockchain.GetBlockByNumber(uint64(end))
 	}
@@ -346,7 +346,7 @@ func (api *PrivateDebugAPI) TraceBlockByNumber(ctx context.Context, number rpc.B
 	case rpc.PendingBlockNumber:
 		block = api.eth.miner.PendingBlock(ctx)
 	case rpc.LatestBlockNumber:
-		block = api.eth.blockchain.CurrentBlockCtx(ctx)
+		block = api.eth.blockchain.CurrentBlock()
 	default:
 		block = api.eth.blockchain.GetBlockByNumber(uint64(number))
 	}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -635,7 +635,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			// Schedule a sync if above ours. Note, this will not fire a sync for a gap of
 			// a singe block (as the true TD is below the propagated block), however this
 			// scenario should easily be covered by the fetcher.
-			currentBlock := pm.blockchain.CurrentBlockCtx(ctx)
+			currentBlock := pm.blockchain.CurrentBlock()
 			if trueTD.Cmp(pm.blockchain.GetTd(currentBlock.Hash(), currentBlock.NumberU64())) > 0 {
 				go pm.synchronise(ctx, p)
 			}

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -225,7 +225,7 @@ func (pm *ProtocolManager) synchronise(ctx context.Context, peer *peer) {
 		return
 	}
 	// Make sure the peer's TD is higher than our own
-	currentBlock := pm.blockchain.CurrentBlockCtx(ctx)
+	currentBlock := pm.blockchain.CurrentBlock()
 	td := pm.blockchain.GetTd(currentBlock.Hash(), currentBlock.NumberU64())
 
 	pHead, pTd := peer.Head()
@@ -263,7 +263,7 @@ func (pm *ProtocolManager) synchronise(ctx context.Context, peer *peer) {
 		atomic.StoreUint32(&pm.fastSync, 0)
 	}
 	atomic.StoreUint32(&pm.acceptTxs, 1) // Mark initial sync done
-	if head := pm.blockchain.CurrentBlockCtx(ctx); head.NumberU64() > 0 {
+	if head := pm.blockchain.CurrentBlock(); head.NumberU64() > 0 {
 		// We've completed a sync cycle, notify all peers of new state. This path is
 		// essential in star-topology networks where a gateway node needs to notify
 		// all its out-of-date peers of the availability of a new block. This failure

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -408,7 +408,7 @@ func (w *worker) commitNewWork(ctx context.Context) {
 	defer w.currentMu.Unlock()
 
 	tstart := time.Now()
-	parent := w.chain.CurrentBlockCtx(ctx)
+	parent := w.chain.CurrentBlock()
 
 	// Ensure we're not going off too far in the future.
 	pTime := time.Unix(parent.Time().Int64(), 0)

--- a/netstats/netstats.go
+++ b/netstats/netstats.go
@@ -578,7 +578,7 @@ func (s *Service) assembleBlockStats(ctx context.Context, block *types.Block) *b
 	if s.eth != nil {
 		// Full nodes have all needed information available
 		if block == nil {
-			block = s.eth.BlockChain().CurrentBlockCtx(ctx)
+			block = s.eth.BlockChain().CurrentBlock()
 		}
 		header = block.Header()
 		td = s.eth.BlockChain().GetTd(header.Hash(), header.Number.Uint64())


### PR DESCRIPTION
This PR modifies `core.Blockchain` by making two fields atomic values (no longer requiring the whole struct mutex to access), and adding a receipts cache.