### PR TITLE
ethdb: Increase header LRU cache size.

### DIFF
--- a/ethdb/db.go
+++ b/ethdb/db.go
@@ -97,7 +97,12 @@ func (db *DB) Open() error {
 	db.receipt = NewTable("receipt", db.TablePath("receipt"), NewBlockNumberPartitioner(db.PartitionSize))
 
 	for _, tbl := range db.Tables() {
+		// Allow 100x header files since they are small.
 		tbl.MaxOpenSegmentCount = db.MaxOpenSegmentCount
+		if tbl.Name == "header" {
+			tbl.MaxOpenSegmentCount *= 100
+		}
+
 		tbl.MinCompactionAge = db.MinCompactionAge
 		tbl.SegmentOpener = db.SegmentOpener
 		tbl.SegmentCompactor = db.SegmentCompactor


### PR DESCRIPTION
This commit sizes the header cache 100x larger than the body and
receipt cache. Header files are significantly smaller and accessed
more frequently.