### PR TITLE
core, eth, les, light: name feed subscribers; log feed delay times; add conservative feed timeout

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -452,7 +452,7 @@ func (fb *filterBackend) GetLogs(ctx context.Context, hash common.Hash) ([][]*ty
 	return logs, nil
 }
 
-func (fb *filterBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) {
+func (fb *filterBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent, _ string) {
 	sub := event.NewSubscription(func(quit <-chan struct{}) error {
 		<-quit
 		return nil
@@ -479,24 +479,24 @@ func (fb *filterBackend) removeSub(ch chan<- core.NewTxsEvent) event.Subscriptio
 	return sub
 }
 
-func (fb *filterBackend) SubscribeChainEvent(ch chan<- core.ChainEvent) {
-	fb.bc.SubscribeChainEvent(ch)
+func (fb *filterBackend) SubscribeChainEvent(ch chan<- core.ChainEvent, name string) {
+	fb.bc.SubscribeChainEvent(ch, name)
 }
 
 func (fb *filterBackend) UnsubscribeChainEvent(ch chan<- core.ChainEvent) {
 	fb.bc.UnsubscribeChainEvent(ch)
 }
 
-func (fb *filterBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) {
-	fb.bc.SubscribeRemovedLogsEvent(ch)
+func (fb *filterBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent, name string) {
+	fb.bc.SubscribeRemovedLogsEvent(ch, name)
 }
 
 func (fb *filterBackend) UnsubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) {
 	fb.bc.UnsubscribeRemovedLogsEvent(ch)
 }
 
-func (fb *filterBackend) SubscribeLogsEvent(ch chan<- []*types.Log) {
-	fb.bc.SubscribeLogsEvent(ch)
+func (fb *filterBackend) SubscribeLogsEvent(ch chan<- []*types.Log, name string) {
+	fb.bc.SubscribeLogsEvent(ch, name)
 }
 
 func (fb *filterBackend) UnsubscribeLogsEvent(ch chan<- []*types.Log) {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1707,8 +1707,8 @@ func (bc *BlockChain) Config() *params.ChainConfig { return bc.chainConfig }
 func (bc *BlockChain) Engine() consensus.Engine { return bc.engine }
 
 // SubscribeRemovedLogsEvent registers a subscription of RemovedLogsEvent.
-func (bc *BlockChain) SubscribeRemovedLogsEvent(ch chan<- RemovedLogsEvent) {
-	bc.rmLogsFeed.Subscribe(ch)
+func (bc *BlockChain) SubscribeRemovedLogsEvent(ch chan<- RemovedLogsEvent, name string) {
+	bc.rmLogsFeed.Subscribe(ch, name)
 }
 
 func (bc *BlockChain) UnsubscribeRemovedLogsEvent(ch chan<- RemovedLogsEvent) {
@@ -1716,8 +1716,8 @@ func (bc *BlockChain) UnsubscribeRemovedLogsEvent(ch chan<- RemovedLogsEvent) {
 }
 
 // SubscribeChainEvent registers a subscription of ChainEvent.
-func (bc *BlockChain) SubscribeChainEvent(ch chan<- ChainEvent) {
-	bc.chainFeed.Subscribe(ch)
+func (bc *BlockChain) SubscribeChainEvent(ch chan<- ChainEvent, name string) {
+	bc.chainFeed.Subscribe(ch, name)
 }
 
 // SubscribeChainEvent registers a subscription of ChainEvent.
@@ -1726,8 +1726,8 @@ func (bc *BlockChain) UnsubscribeChainEvent(ch chan<- ChainEvent) {
 }
 
 // SubscribeChainHeadEvent registers a subscription of ChainHeadEvent.
-func (bc *BlockChain) SubscribeChainHeadEvent(ch chan<- ChainHeadEvent) {
-	bc.chainHeadFeed.Subscribe(ch)
+func (bc *BlockChain) SubscribeChainHeadEvent(ch chan<- ChainHeadEvent, name string) {
+	bc.chainHeadFeed.Subscribe(ch, name)
 }
 
 // SubscribeChainHeadEvent registers a subscription of ChainHeadEvent.
@@ -1736,8 +1736,8 @@ func (bc *BlockChain) UnsubscribeChainHeadEvent(ch chan<- ChainHeadEvent) {
 }
 
 // SubscribeChainSideEvent registers a subscription of ChainSideEvent.
-func (bc *BlockChain) SubscribeChainSideEvent(ch chan<- ChainSideEvent) {
-	bc.chainSideFeed.Subscribe(ch)
+func (bc *BlockChain) SubscribeChainSideEvent(ch chan<- ChainSideEvent, name string) {
+	bc.chainSideFeed.Subscribe(ch, name)
 }
 
 func (bc *BlockChain) UnsubscribeChainSideEvent(ch chan<- ChainSideEvent) {
@@ -1745,8 +1745,8 @@ func (bc *BlockChain) UnsubscribeChainSideEvent(ch chan<- ChainSideEvent) {
 }
 
 // SubscribeLogsEvent registers a subscription of []*types.Log.
-func (bc *BlockChain) SubscribeLogsEvent(ch chan<- []*types.Log) {
-	bc.logsFeed.Subscribe(ch)
+func (bc *BlockChain) SubscribeLogsEvent(ch chan<- []*types.Log, name string) {
+	bc.logsFeed.Subscribe(ch, name)
 }
 
 func (bc *BlockChain) UnsubscribeLogsEvent(ch chan<- []*types.Log) {

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -960,7 +960,7 @@ func TestLogReorgs(t *testing.T) {
 	defer blockchain.Stop()
 
 	rmLogsCh := make(chan RemovedLogsEvent, 1)
-	blockchain.SubscribeRemovedLogsEvent(rmLogsCh)
+	blockchain.SubscribeRemovedLogsEvent(rmLogsCh, "test")
 	chain, _ := GenerateChain(ctx, params.TestChainConfig, genesis, engine, db, 2, func(ctx context.Context, i int, gen *BlockGen) {
 		if i == 1 {
 			tx, err := types.SignTx(types.NewContractCreation(gen.TxNonce(addr1), new(big.Int), 1000000, new(big.Int), code), signer, key1)
@@ -1024,7 +1024,7 @@ func TestReorgSideEvent(t *testing.T) {
 		gen.AddTx(ctx, tx)
 	})
 	chainSideCh := make(chan ChainSideEvent, 64)
-	blockchain.SubscribeChainSideEvent(chainSideCh)
+	blockchain.SubscribeChainSideEvent(chainSideCh, "test")
 	if _, err := blockchain.InsertChain(ctx, replacementBlocks); err != nil {
 		t.Fatalf("failed to insert chain: %v", err)
 	}

--- a/core/chain_indexer.go
+++ b/core/chain_indexer.go
@@ -51,7 +51,7 @@ type ChainIndexerChain interface {
 	CurrentHeader() *types.Header
 
 	// SubscribeChainHeadEvent subscribes to new head header notifications.
-	SubscribeChainHeadEvent(ch chan<- ChainHeadEvent)
+	SubscribeChainHeadEvent(ch chan<- ChainHeadEvent, name string)
 	UnsubscribeChainHeadEvent(ch chan<- ChainHeadEvent)
 }
 
@@ -127,7 +127,7 @@ func (c *ChainIndexer) AddKnownSectionHead(section uint64, shead common.Hash) {
 // are notified about new events by their parents.
 func (c *ChainIndexer) Start(chain ChainIndexerChain) {
 	events := make(chan ChainHeadEvent, 32)
-	chain.SubscribeChainHeadEvent(events)
+	chain.SubscribeChainHeadEvent(events, "core.ChainIndexer")
 	// Mark the chain indexer as active, requiring an additional teardown
 	atomic.StoreUint32(&c.active, 1)
 	go c.eventLoop(chain, events)

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -133,7 +133,7 @@ type blockChain interface {
 	GetBlock(hash common.Hash, number uint64) *types.Block
 	StateAt(root common.Hash) (*state.StateDB, error)
 
-	SubscribeChainHeadEvent(ch chan<- ChainHeadEvent)
+	SubscribeChainHeadEvent(ch chan<- ChainHeadEvent, name string)
 	UnsubscribeChainHeadEvent(ch chan<- ChainHeadEvent)
 }
 
@@ -295,7 +295,7 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain block
 	}
 
 	// Subscribe events from blockchain.
-	pool.chain.SubscribeChainHeadEvent(pool.chainHeadCh)
+	pool.chain.SubscribeChainHeadEvent(pool.chainHeadCh, "core.TxPool")
 	// Spawn worker routines to run until chainHeadSub unsub.
 	pool.wg.Add(3)
 	pool.stop = make(chan struct{})
@@ -639,8 +639,8 @@ func (pool *TxPool) Stop() {
 
 // SubscribeNewTxsEvent registers a subscription of NewTxsEvent and
 // starts sending event to the given channel.
-func (pool *TxPool) SubscribeNewTxsEvent(ch chan<- NewTxsEvent) {
-	pool.txFeed.Subscribe(ch)
+func (pool *TxPool) SubscribeNewTxsEvent(ch chan<- NewTxsEvent, name string) {
+	pool.txFeed.Subscribe(ch, name)
 }
 
 func (pool *TxPool) UnsubscribeNewTxsEvent(ch chan<- NewTxsEvent) {

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -90,8 +90,8 @@ func (bc *testBlockChain) StateAt(common.Hash) (*state.StateDB, error) {
 	return bc.statedb, nil
 }
 
-func (bc *testBlockChain) SubscribeChainHeadEvent(ch chan<- ChainHeadEvent) {
-	bc.chainHeadFeed.Subscribe(ch)
+func (bc *testBlockChain) SubscribeChainHeadEvent(ch chan<- ChainHeadEvent, name string) {
+	bc.chainHeadFeed.Subscribe(ch, name)
 }
 
 func (bc *testBlockChain) UnsubscribeChainHeadEvent(ch chan<- ChainHeadEvent) {
@@ -811,7 +811,7 @@ func TestTransactionGapFilling(t *testing.T) {
 
 	// Keep track of transaction events to ensure all executables get announced
 	events := make(chan NewTxsEvent, testTxPoolConfig.AccountQueue+5)
-	pool.SubscribeNewTxsEvent(events)
+	pool.SubscribeNewTxsEvent(events, "test")
 	pool.mu.Unlock()
 	defer pool.UnsubscribeNewTxsEvent(events)
 
@@ -1095,7 +1095,7 @@ func TestTransactionPendingLimiting(t *testing.T) {
 
 	// Keep track of transaction events to ensure all executables get announced
 	events := make(chan NewTxsEvent, testTxPoolConfig.AccountQueue+5)
-	pool.SubscribeNewTxsEvent(events)
+	pool.SubscribeNewTxsEvent(events, "test")
 	pool.mu.Unlock()
 	defer pool.UnsubscribeNewTxsEvent(events)
 
@@ -1349,7 +1349,7 @@ func TestTransactionPoolRepricing(t *testing.T) {
 	// Keep track of transaction events to ensure all executables get announced
 	events := make(chan NewTxsEvent, 32)
 	pool.mu.Lock()
-	pool.SubscribeNewTxsEvent(events)
+	pool.SubscribeNewTxsEvent(events, "test")
 	pool.mu.Unlock()
 	defer pool.UnsubscribeNewTxsEvent(events)
 
@@ -1519,7 +1519,7 @@ func TestTransactionPoolUnderpricing(t *testing.T) {
 	// Keep track of transaction events to ensure all executables get announced
 	events := make(chan NewTxsEvent, 32)
 	pool.mu.Lock()
-	pool.SubscribeNewTxsEvent(events)
+	pool.SubscribeNewTxsEvent(events, "test")
 	pool.mu.Unlock()
 	defer pool.UnsubscribeNewTxsEvent(events)
 
@@ -1601,7 +1601,7 @@ func TestTransactionPoolStableUnderpricing(t *testing.T) {
 
 	// Keep track of transaction events to ensure all executables get announced
 	events := make(chan NewTxsEvent, 1024)
-	pool.SubscribeNewTxsEvent(events)
+	pool.SubscribeNewTxsEvent(events, "test")
 	defer pool.UnsubscribeNewTxsEvent(events)
 
 	// Create a number of test accounts and fund them
@@ -1671,7 +1671,7 @@ func TestTransactionReplacement(t *testing.T) {
 	// Keep track of transaction events to ensure all executables get announced
 	events := make(chan NewTxsEvent, 32)
 	pool.mu.Lock()
-	pool.SubscribeNewTxsEvent(events)
+	pool.SubscribeNewTxsEvent(events, "test")
 	defer pool.UnsubscribeNewTxsEvent(events)
 
 	// Create a test account to add transactions with

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -173,40 +173,40 @@ func (b *EthApiBackend) GetEVM(ctx context.Context, msg core.Message, state *sta
 	return vm.NewEVM(context, state, b.eth.chainConfig, vmCfg), nil
 }
 
-func (b *EthApiBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) {
-	b.eth.BlockChain().SubscribeRemovedLogsEvent(ch)
+func (b *EthApiBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent, name string) {
+	b.eth.BlockChain().SubscribeRemovedLogsEvent(ch, name)
 }
 
 func (b *EthApiBackend) UnsubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) {
 	b.eth.BlockChain().UnsubscribeRemovedLogsEvent(ch)
 }
 
-func (b *EthApiBackend) SubscribeChainEvent(ch chan<- core.ChainEvent) {
-	b.eth.BlockChain().SubscribeChainEvent(ch)
+func (b *EthApiBackend) SubscribeChainEvent(ch chan<- core.ChainEvent, name string) {
+	b.eth.BlockChain().SubscribeChainEvent(ch, name)
 }
 
 func (b *EthApiBackend) UnsubscribeChainEvent(ch chan<- core.ChainEvent) {
 	b.eth.BlockChain().UnsubscribeChainEvent(ch)
 }
 
-func (b *EthApiBackend) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) {
-	b.eth.BlockChain().SubscribeChainHeadEvent(ch)
+func (b *EthApiBackend) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent, name string) {
+	b.eth.BlockChain().SubscribeChainHeadEvent(ch, name)
 }
 
 func (b *EthApiBackend) UnsubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) {
 	b.eth.BlockChain().UnsubscribeChainHeadEvent(ch)
 }
 
-func (b *EthApiBackend) SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) {
-	b.eth.BlockChain().SubscribeChainSideEvent(ch)
+func (b *EthApiBackend) SubscribeChainSideEvent(ch chan<- core.ChainSideEvent, name string) {
+	b.eth.BlockChain().SubscribeChainSideEvent(ch, name)
 }
 
 func (b *EthApiBackend) UnsubscribeChainSideEvent(ch chan<- core.ChainSideEvent) {
 	b.eth.BlockChain().UnsubscribeChainSideEvent(ch)
 }
 
-func (b *EthApiBackend) SubscribeLogsEvent(ch chan<- []*types.Log) {
-	b.eth.BlockChain().SubscribeLogsEvent(ch)
+func (b *EthApiBackend) SubscribeLogsEvent(ch chan<- []*types.Log, name string) {
+	b.eth.BlockChain().SubscribeLogsEvent(ch, name)
 }
 
 func (b *EthApiBackend) UnsubscribeLogsEvent(ch chan<- []*types.Log) {
@@ -242,8 +242,8 @@ func (b *EthApiBackend) TxPoolContent(ctx context.Context) (map[common.Address]t
 	return b.eth.TxPool().Content(ctx)
 }
 
-func (b *EthApiBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) {
-	b.eth.TxPool().SubscribeNewTxsEvent(ch)
+func (b *EthApiBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent, name string) {
+	b.eth.TxPool().SubscribeNewTxsEvent(ch, name)
 }
 
 func (b *EthApiBackend) UnsubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) {

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -34,13 +34,13 @@ type Backend interface {
 	HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Header, error)
 	GetReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error)
 
-	SubscribeNewTxsEvent(chan<- core.NewTxsEvent)
-	UnsubscribeNewTxsEvent(chan<- core.NewTxsEvent)
-	SubscribeChainEvent(ch chan<- core.ChainEvent)
+	SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent, name string)
+	UnsubscribeNewTxsEvent(ch chan<- core.NewTxsEvent)
+	SubscribeChainEvent(ch chan<- core.ChainEvent, name string)
 	UnsubscribeChainEvent(ch chan<- core.ChainEvent)
-	SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent)
+	SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent, name string)
 	UnsubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent)
-	SubscribeLogsEvent(ch chan<- []*types.Log)
+	SubscribeLogsEvent(ch chan<- []*types.Log, name string)
 	UnsubscribeLogsEvent(ch chan<- []*types.Log)
 
 	BloomStatus() (uint64, uint64)

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -125,10 +125,11 @@ func NewEventSystem(mux *event.TypeMux, backend Backend, lightMode bool) *EventS
 	}
 
 	// Subscribe events
-	m.backend.SubscribeNewTxsEvent(m.txsCh)
-	m.backend.SubscribeLogsEvent(m.logsCh)
-	m.backend.SubscribeRemovedLogsEvent(m.rmLogsCh)
-	m.backend.SubscribeChainEvent(m.chainCh)
+	const name = "eth/filters.EventSystem"
+	m.backend.SubscribeNewTxsEvent(m.txsCh, name)
+	m.backend.SubscribeLogsEvent(m.logsCh, name)
+	m.backend.SubscribeRemovedLogsEvent(m.rmLogsCh, name)
+	m.backend.SubscribeChainEvent(m.chainCh, name)
 	// TODO(rjl493456442): use feed to subscribe pending log event
 	m.pendingLogSub = m.mux.Subscribe(core.PendingLogsEvent{})
 

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -88,32 +88,32 @@ func (b *testBackend) GetReceipts(ctx context.Context, hash common.Hash) (types.
 	return nil, nil
 }
 
-func (b *testBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) {
-	b.txFeed.Subscribe(ch)
+func (b *testBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent, name string) {
+	b.txFeed.Subscribe(ch, name)
 }
 
 func (b *testBackend) UnsubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) {
 	b.txFeed.Unsubscribe(ch)
 }
 
-func (b *testBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) {
-	b.rmLogsFeed.Subscribe(ch)
+func (b *testBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent, name string) {
+	b.rmLogsFeed.Subscribe(ch, name)
 }
 
 func (b *testBackend) UnsubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) {
 	b.rmLogsFeed.Unsubscribe(ch)
 }
 
-func (b *testBackend) SubscribeLogsEvent(ch chan<- []*types.Log) {
-	b.logsFeed.Subscribe(ch)
+func (b *testBackend) SubscribeLogsEvent(ch chan<- []*types.Log, name string) {
+	b.logsFeed.Subscribe(ch, name)
 }
 
 func (b *testBackend) UnsubscribeLogsEvent(ch chan<- []*types.Log) {
 	b.logsFeed.Unsubscribe(ch)
 }
 
-func (b *testBackend) SubscribeChainEvent(ch chan<- core.ChainEvent) {
-	b.chainFeed.Subscribe(ch)
+func (b *testBackend) SubscribeChainEvent(ch chan<- core.ChainEvent, name string) {
+	b.chainFeed.Subscribe(ch, name)
 }
 
 func (b *testBackend) UnsubscribeChainEvent(ch chan<- core.ChainEvent) {

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -210,7 +210,7 @@ func (pm *ProtocolManager) Start(maxPeers int) {
 
 	// broadcast transactions
 	pm.txsCh = make(chan core.NewTxsEvent, txChanSize)
-	pm.txpool.SubscribeNewTxsEvent(pm.txsCh)
+	pm.txpool.SubscribeNewTxsEvent(pm.txsCh, "eth.ProtocolManager")
 	go pm.txBroadcastLoop()
 
 	// broadcast mined blocks

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -135,8 +135,8 @@ func (p *testTxPool) PendingList(ctx context.Context) types.Transactions {
 	return pending
 }
 
-func (p *testTxPool) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) {
-	p.txFeed.Subscribe(ch)
+func (p *testTxPool) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent, name string) {
+	p.txFeed.Subscribe(ch, name)
 }
 
 func (p *testTxPool) UnsubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) {

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -110,7 +110,7 @@ type txPool interface {
 
 	// SubscribeNewTxsEvent should return an event subscription of
 	// NewTxsEvent and send events to the given channel.
-	SubscribeNewTxsEvent(chan<- core.NewTxsEvent)
+	SubscribeNewTxsEvent(chan<- core.NewTxsEvent, string)
 	UnsubscribeNewTxsEvent(chan<- core.NewTxsEvent)
 }
 

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -55,11 +55,11 @@ type Backend interface {
 	GetReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error)
 	GetTd(blockHash common.Hash) *big.Int
 	GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header, vmCfg vm.Config) (*vm.EVM, error)
-	SubscribeChainEvent(ch chan<- core.ChainEvent)
+	SubscribeChainEvent(ch chan<- core.ChainEvent, name string)
 	UnsubscribeChainEvent(ch chan<- core.ChainEvent)
-	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent)
+	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent, name string)
 	UnsubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent)
-	SubscribeChainSideEvent(ch chan<- core.ChainSideEvent)
+	SubscribeChainSideEvent(ch chan<- core.ChainSideEvent, name string)
 	UnsubscribeChainSideEvent(ch chan<- core.ChainSideEvent)
 
 	// TxPool API
@@ -69,7 +69,7 @@ type Backend interface {
 	GetPoolNonce(ctx context.Context, addr common.Address) (uint64, error)
 	Stats() (pending int, queued int)
 	TxPoolContent(context.Context) (map[common.Address]types.Transactions, map[common.Address]types.Transactions)
-	SubscribeNewTxsEvent(chan<- core.NewTxsEvent)
+	SubscribeNewTxsEvent(chan<- core.NewTxsEvent, string)
 	UnsubscribeNewTxsEvent(chan<- core.NewTxsEvent)
 
 	ChainConfig() *params.ChainConfig

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -159,43 +159,43 @@ func (b *LesApiBackend) TxPoolContent(ctx context.Context) (map[common.Address]t
 	return b.eth.txPool.Content(ctx)
 }
 
-func (b *LesApiBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) {
-	b.eth.txPool.SubscribeNewTxsEvent(ch)
+func (b *LesApiBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent, name string) {
+	b.eth.txPool.SubscribeNewTxsEvent(ch, name)
 }
 
 func (b *LesApiBackend) UnsubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) {
 	b.eth.txPool.UnsubscribeNewTxsEvent(ch)
 }
 
-func (b *LesApiBackend) SubscribeChainEvent(ch chan<- core.ChainEvent) {
-	b.eth.blockchain.SubscribeChainEvent(ch)
+func (b *LesApiBackend) SubscribeChainEvent(ch chan<- core.ChainEvent, name string) {
+	b.eth.blockchain.SubscribeChainEvent(ch, name)
 }
 
 func (b *LesApiBackend) UnsubscribeChainEvent(ch chan<- core.ChainEvent) {
 	b.eth.blockchain.UnsubscribeChainEvent(ch)
 }
 
-func (b *LesApiBackend) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) {
-	b.eth.blockchain.SubscribeChainHeadEvent(ch)
+func (b *LesApiBackend) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent, name string) {
+	b.eth.blockchain.SubscribeChainHeadEvent(ch, name)
 }
 
 func (b *LesApiBackend) UnsubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) {
 	b.eth.blockchain.UnsubscribeChainHeadEvent(ch)
 }
 
-func (b *LesApiBackend) SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) {
-	b.eth.blockchain.SubscribeChainSideEvent(ch)
+func (b *LesApiBackend) SubscribeChainSideEvent(ch chan<- core.ChainSideEvent, name string) {
+	b.eth.blockchain.SubscribeChainSideEvent(ch, name)
 }
 
 func (b *LesApiBackend) UnsubscribeChainSideEvent(ch chan<- core.ChainSideEvent) {
 	b.eth.blockchain.UnsubscribeChainSideEvent(ch)
 }
 
-func (b *LesApiBackend) SubscribeLogsEvent(ch chan<- []*types.Log) {}
+func (b *LesApiBackend) SubscribeLogsEvent(ch chan<- []*types.Log, name string) {}
 
 func (b *LesApiBackend) UnsubscribeLogsEvent(ch chan<- []*types.Log) {}
 
-func (b *LesApiBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) {}
+func (b *LesApiBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent, name string) {}
 
 func (b *LesApiBackend) UnsubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) {}
 

--- a/les/handler.go
+++ b/les/handler.go
@@ -86,7 +86,7 @@ type BlockChain interface {
 	GetHeaderByNumber(number uint64) *types.Header
 	GetAncestor(hash common.Hash, number, ancestor uint64, maxNonCanonical *uint64) (common.Hash, uint64)
 	Genesis() *types.Block
-	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent)
+	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent, name string)
 	UnsubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent)
 }
 

--- a/les/server.go
+++ b/les/server.go
@@ -322,7 +322,7 @@ func (s *requestCostStats) update(msgCode, reqCnt, cost uint64) {
 func (pm *ProtocolManager) blockLoop() {
 	pm.wg.Add(1)
 	headCh := make(chan core.ChainHeadEvent, 100)
-	pm.blockchain.SubscribeChainHeadEvent(headCh)
+	pm.blockchain.SubscribeChainHeadEvent(headCh, "les.ProtocolManger-blockLoop")
 	go func() {
 		var lastHead *types.Header
 		lastBroadcastTd := common.Big0

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -496,8 +496,8 @@ func (self *LightChain) UnlockChain() {
 }
 
 // SubscribeChainEvent registers a subscription of ChainEvent.
-func (lc *LightChain) SubscribeChainEvent(ch chan<- core.ChainEvent) {
-	lc.chainFeed.Subscribe(ch)
+func (lc *LightChain) SubscribeChainEvent(ch chan<- core.ChainEvent, name string) {
+	lc.chainFeed.Subscribe(ch, name)
 }
 
 func (lc *LightChain) UnsubscribeChainEvent(ch chan<- core.ChainEvent) {
@@ -505,8 +505,8 @@ func (lc *LightChain) UnsubscribeChainEvent(ch chan<- core.ChainEvent) {
 }
 
 // SubscribeChainHeadEvent registers a subscription of ChainHeadEvent.
-func (lc *LightChain) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) {
-	lc.chainHeadFeed.Subscribe(ch)
+func (lc *LightChain) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent, name string) {
+	lc.chainHeadFeed.Subscribe(ch, name)
 }
 
 func (lc *LightChain) UnsubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) {
@@ -514,8 +514,8 @@ func (lc *LightChain) UnsubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) {
 }
 
 // SubscribeChainSideEvent registers a subscription of ChainSideEvent.
-func (lc *LightChain) SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) {
-	lc.chainSideFeed.Subscribe(ch)
+func (lc *LightChain) SubscribeChainSideEvent(ch chan<- core.ChainSideEvent, name string) {
+	lc.chainSideFeed.Subscribe(ch, name)
 }
 
 func (lc *LightChain) UnsubscribeChainSideEvent(ch chan<- core.ChainSideEvent) {

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -101,7 +101,7 @@ func NewTxPool(config *params.ChainConfig, chain *LightChain, relay TxRelayBacke
 		head:        chain.CurrentHeader().Hash(),
 		clearIdx:    chain.CurrentHeader().Number.Uint64(),
 	}
-	pool.chain.SubscribeChainHeadEvent(pool.chainHeadCh)
+	pool.chain.SubscribeChainHeadEvent(pool.chainHeadCh, "light.TxPool")
 	go pool.eventLoop()
 
 	return pool
@@ -316,8 +316,8 @@ func (pool *TxPool) Stop() {
 
 // SubscribeNewTxsEvent registers a subscription of core.NewTxsEvent and
 // starts sending event to the given channel.
-func (pool *TxPool) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) {
-	pool.txFeed.Subscribe(ch)
+func (pool *TxPool) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent, name string) {
+	pool.txFeed.Subscribe(ch, name)
 }
 
 func (pool *TxPool) UnsubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -133,8 +133,8 @@ func newWorker(config *params.ChainConfig, engine consensus.Engine, coinbase com
 		agents:      make(map[Agent]struct{}),
 		unconfirmed: newUnconfirmedBlocks(eth.BlockChain(), miningLogAtDepth),
 	}
-	eth.TxPool().SubscribeNewTxsEvent(worker.txsCh)
-	eth.BlockChain().SubscribeChainHeadEvent(worker.chainHeadCh)
+	eth.TxPool().SubscribeNewTxsEvent(worker.txsCh, "miner.worker")
+	eth.BlockChain().SubscribeChainHeadEvent(worker.chainHeadCh, "miner.worker")
 	go worker.update()
 
 	go worker.wait()

--- a/netstats/netstats.go
+++ b/netstats/netstats.go
@@ -52,13 +52,13 @@ const (
 )
 
 type txPool interface {
-	SubscribeNewTxsEvent(chan<- core.NewTxsEvent)
+	SubscribeNewTxsEvent(chan<- core.NewTxsEvent, string)
 	UnsubscribeNewTxsEvent(chan<- core.NewTxsEvent)
 }
 
 type blockChain interface {
-	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent)
-	UnsubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent)
+	SubscribeChainHeadEvent(chan<- core.ChainHeadEvent, string)
+	UnsubscribeChainHeadEvent(chan<- core.ChainHeadEvent)
 }
 
 // Service implements an GoChain netstats reporting daemon that pushes local
@@ -163,8 +163,8 @@ func (s *Service) loop() {
 		headCh      = make(chan *types.Block, 1)
 		txCh        = make(chan struct{}, 1)
 	)
-	blockchain.SubscribeChainHeadEvent(chainHeadCh)
-	txpool.SubscribeNewTxsEvent(txEventCh)
+	blockchain.SubscribeChainHeadEvent(chainHeadCh, "netstats.Service")
+	txpool.SubscribeNewTxsEvent(txEventCh, "netstats.Service")
 	go func() {
 		defer close(quitCh)
 		defer blockchain.UnsubscribeChainHeadEvent(chainHeadCh)


### PR DESCRIPTION
This PR is a follow up from #289. It allows feed subscribers to associate a `name` with the channel, and if the initial send is blocked then the delay is measured and logged along with the `name` of the channel that was full. The timeout was also restored to drop the send attempt (and log about it) if it takes longer than `500ms`. (`NewTxsEvent`/`NewTxsFeed` is still an exception.)