### PR TITLE
consensus/clique: delay out-of-turn broadcasts from deadline, rather than end of period

### DIFF
--- a/consensus/clique/clique_test.go
+++ b/consensus/clique/clique_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/gochain-io/gochain/common"
 )
@@ -218,6 +219,24 @@ func (test *testCalcDifficulty) run(t *testing.T) {
 		got := CalcDifficulty(test.lastSigned, signer)
 		if got != uint64(exp) {
 			t.Errorf("expected difficulty %d but got %d", exp, got)
+		}
+	}
+}
+
+func TestPrepareDeadline(t *testing.T) {
+	now := time.Now().Round(time.Second)
+	for _, test := range []struct {
+		unix   int64
+		period uint64
+		want   time.Time
+	}{
+		{unix: 3, period: 3, want: time.Unix(1, 0)},
+		{unix: 6, period: 6, want: time.Unix(2, 0)},
+		{unix: now.Unix(), period: 6, want: now.Add(-4 * time.Second)},
+		{unix: 123456789, period: 300, want: time.Unix(123456589, 0)},
+	} {
+		if got := prepareDeadline(test.unix, test.period); *got != test.want {
+			t.Errorf("%q:%d - wanted %q but got %q", time.Unix(test.unix, 0), 6, test.want, got)
 		}
 	}
 }


### PR DESCRIPTION
This PR is a follow up from #291, which moves the broadcast time for out-of-turn blocks from the *end of the period* to the *deadline*. The staggered delay is still used, but starts earlier (deadline is 1/3 of period right now) which will improve performance and produce a more gradual slowdown when signing out-of-turn - i.e. if one node is down, we just pay the `100ms` delay time, instead of waiting until the end of the period first (an extra ~`3.3s`).