### PR TITLE
core: improve tx pool batching; align tx feed with others

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -498,6 +498,15 @@ func (pool *TxPool) feedLoop() {
 				}
 			}
 			pool.txFeed.Send(event)
+
+			// Unless another full batch is ready, then wait a bit.
+			if len(pool.txFeedBuf) < batchSize {
+				select {
+				case <-pool.stop:
+					return
+				case <-time.After(50 * time.Millisecond):
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR improves the tx batching from the pool by delaying a bit to allow larger batches to accumulate, which allows the tx feed to operate more normally (like the others) and block instead of dropping immediately. The expected effect is to 1) build up larger batches and 2) have back pressure when blocked so that real queued work gets done instead of the batcher just spinning and dropping a bunch of tx batches of single txs. This should lead to 3) dropping less txs overall and logging more visibly when we do. When blocked, the tx pool itself will not be blocked since there is still a (huge) feed buffer channel in between that would also need to fill completely. In the worst case, log spam should be greatly reduced since drops are effectively rate limited by the timeout - so we'll see a few messages of large batches being dropped rather than tons of messages for single txs being dropped - this enabled raising the log level to make them more visible as well.