### PR TITLE
eth, miner: increase NewTxsEvent subscriber channel buffers; worker - process events in batch

### DIFF
--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -60,7 +60,7 @@ const (
 
 	// txChanSize is the size of channel listening to NewTxsEvent.
 	// The number is referenced from the size of tx pool.
-	txChanSize = 4096
+	txChanSize = 16384
 	// rmLogsChanSize is the size of channel listening to RemovedLogsEvent.
 	rmLogsChanSize = 32
 	// logsChanSize is the size of channel listening to LogsEvent.

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -48,7 +48,7 @@ const (
 
 	// txChanSize is the size of channel listening to NewTxsEvent.
 	// The number is referenced from the size of tx pool.
-	txChanSize = 4096
+	txChanSize = 16384
 
 	// The smallest subset of peers to broadcast to.
 	minBroadcastPeers = 4

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -41,7 +41,7 @@ const (
 
 	// txChanSize is the size of channel listening to NewTxsEvent.
 	// The number is referenced from the size of tx pool.
-	txChanSize = 4096
+	txChanSize = 16384
 	// chainHeadChanSize is the size of channel listening to ChainHeadEvent.
 	chainHeadChanSize = 32
 )
@@ -259,10 +259,24 @@ func (w *worker) update() {
 			span.End()
 
 		// Handle NewTxsEvent
-		case ev, ok := <-w.txsCh:
+		case first, ok := <-w.txsCh:
 			if !ok {
 				return
 			}
+			evs := []core.NewTxsEvent{first}
+			// Check for more ready events.
+			for len(evs) < 1000 {
+				select {
+				case ev, ok := <-w.txsCh:
+					if !ok {
+						return
+					}
+					evs = append(evs, ev)
+				default:
+					break
+				}
+			}
+
 			ctx, span := trace.StartSpan(context.Background(), "worker.update-txsCh")
 			// Apply transaction to the pending state if we're not mining
 			//
@@ -274,9 +288,11 @@ func (w *worker) update() {
 				w.current.stateMu.Lock()
 
 				txs := make(map[common.Address]types.Transactions)
-				for _, tx := range ev.Txs {
-					acc, _ := types.Sender(ctx, w.current.signer, tx)
-					txs[acc] = append(txs[acc], tx)
+				for _, ev := range evs {
+					for _, tx := range ev.Txs {
+						acc, _ := types.Sender(ctx, w.current.signer, tx)
+						txs[acc] = append(txs[acc], tx)
+					}
 				}
 				txset := types.NewTransactionsByPriceAndNonce(ctx, w.current.signer, txs)
 				w.current.commitTransactions(ctx, nil, w.mux, txset, w.chain, w.coinbase)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -265,6 +265,7 @@ func (w *worker) update() {
 			}
 			evs := []core.NewTxsEvent{first}
 			// Check for more ready events.
+		batchloop:
 			for len(evs) < 1000 {
 				select {
 				case ev, ok := <-w.txsCh:
@@ -273,7 +274,7 @@ func (w *worker) update() {
 					}
 					evs = append(evs, ev)
 				default:
-					break
+					break batchloop
 				}
 			}
 


### PR DESCRIPTION
This PR increases the size of the `NewTxsEvent` feed subscriber buffers (which were still sized based on the geth pool default config), and also changes the `worker` to process events in batch. The goal is to reduce the number of feed send delays/drops on the proxies:
![screenshot from 2018-10-18 17-56-40](https://user-images.githubusercontent.com/1194128/47188801-34da1100-d2ff-11e8-9043-3cf31bf20d89.png)
