### PR TITLE
core, core/rawdb, eth, light: retry rawdb failures with backoff instead of shutting down

### DIFF
--- a/common/db.go
+++ b/common/db.go
@@ -16,7 +16,12 @@
 
 package common
 
-import "io"
+import (
+	"errors"
+	"io"
+)
+
+var ErrNotFound = errors.New("not found")
 
 // Database wraps all database operations. All methods are safe for concurrent use.
 type Database interface {

--- a/core/rawdb/interfaces.go
+++ b/core/rawdb/interfaces.go
@@ -19,6 +19,7 @@ package rawdb
 // DatabaseReader wraps the Has and Get method of a backing data store.
 type DatabaseReader interface {
 	Has(key []byte) (bool, error)
+	// Get returns the data for key, or an error. Must return common.ErrNotFound when not found.
 	Get(key []byte) ([]byte, error)
 }
 

--- a/core/rawdb/retry.go
+++ b/core/rawdb/retry.go
@@ -1,0 +1,38 @@
+package rawdb
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gochain-io/gochain/common"
+	"github.com/gochain-io/gochain/log"
+)
+
+const (
+	initialDelay = 1 * time.Second
+	maxDelay     = 30 * time.Second
+)
+
+// Must executes fn, repeatedly retrying (with increasing delay) until it returns nil. op describes the operation for
+// error logging.
+func Must(op string, fn func() error) {
+	err := fn()
+	if err == nil {
+		return
+	}
+	start := time.Now()
+	cnt := 1
+	delay := initialDelay
+	msg := fmt.Sprintf("Failed to %q; retrying after delay", op)
+	for err != nil {
+		log.Error(msg, "attempt", cnt, "delay", common.PrettyDuration(delay), "err", err)
+		cnt++
+		delay *= 2
+		if delay > maxDelay {
+			delay = maxDelay
+		}
+		time.Sleep(delay)
+		err = fn()
+	}
+	log.Info(fmt.Sprintf("Successful %q after retrying", op), "attempts", cnt, "dur", common.PrettyDuration(time.Since(start)))
+}

--- a/eth/bloombits.go
+++ b/eth/bloombits.go
@@ -142,5 +142,6 @@ func (b *BloomIndexer) Commit() error {
 		}
 		rawdb.WriteBloomBits(batch, uint(i), b.section, b.head, bitutil.CompressBytes(bits))
 	}
-	return batch.Write()
+	rawdb.Must("write bloom bits batch", batch.Write)
+	return nil
 }

--- a/ethdb/file_segment.go
+++ b/ethdb/file_segment.go
@@ -20,7 +20,6 @@ import (
 )
 
 var (
-	ErrKeyNotFound                 = errors.New("ethdb: key not found")
 	ErrImmutableSegment            = errors.New("ethdb: immutable segment")
 	ErrSegmentTypeUnknown          = errors.New("ethdb: segment type unknown")
 	ErrFileSegmentChecksumMismatch = errors.New("ethdb: file segment checksum mismatch")
@@ -183,7 +182,7 @@ func (s *FileSegment) Get(key []byte) ([]byte, error) {
 
 	_, voff := s.offset(key)
 	if voff == 0 {
-		return nil, ErrKeyNotFound
+		return nil, common.ErrNotFound
 	}
 
 	// Read value.

--- a/ethdb/file_segment_test.go
+++ b/ethdb/file_segment_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"testing/quick"
 
+	"github.com/gochain-io/gochain/common"
+
 	"github.com/gochain-io/gochain/ethdb"
 )
 
@@ -45,7 +47,7 @@ func TestFileSegment_Get(t *testing.T) {
 		}
 
 		// Fetch unknown key.
-		if v, err := s.Get([]byte("no_such_key")); err != ethdb.ErrKeyNotFound {
+		if v, err := s.Get([]byte("no_such_key")); err != common.ErrNotFound {
 			t.Fatalf("unexpected error: %s", err)
 		} else if v != nil {
 			t.Fatalf("expected nil value, got %q", v)

--- a/ethdb/ldb_segment.go
+++ b/ethdb/ldb_segment.go
@@ -1,6 +1,7 @@
 package ethdb
 
 import (
+	"github.com/gochain-io/gochain/common"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/filter"
 	"github.com/syndtr/goleveldb/leveldb/iterator"
@@ -61,7 +62,7 @@ func (s *LDBSegment) Has(key []byte) (bool, error) {
 func (s *LDBSegment) Get(key []byte) ([]byte, error) {
 	value, err := s.db.Get(key, nil)
 	if err == leveldb.ErrNotFound {
-		return nil, ErrKeyNotFound
+		return nil, common.ErrNotFound
 	}
 	return value, err
 }

--- a/ethdb/memory_database.go
+++ b/ethdb/memory_database.go
@@ -17,7 +17,6 @@
 package ethdb
 
 import (
-	"errors"
 	"sync"
 
 	"github.com/gochain-io/gochain/common"
@@ -71,7 +70,7 @@ func (db *MemDatabase) Get(key []byte) ([]byte, error) {
 	if entry, ok := db.db[string(key)]; ok {
 		return common.CopyBytes(entry), nil
 	}
-	return nil, errors.New("not found")
+	return nil, common.ErrNotFound
 }
 
 func (db *MemDatabase) Keys() [][]byte {

--- a/ethdb/table.go
+++ b/ethdb/table.go
@@ -268,7 +268,7 @@ func (t *Table) Has(key []byte) (bool, error) {
 	if err != nil {
 		return false, err
 	} else if s == nil {
-		return false, ErrKeyNotFound
+		return false, common.ErrNotFound
 	}
 	defer t.ReleaseSegment(s)
 	return s.Has(key)
@@ -290,7 +290,7 @@ func (t *Table) Get(key []byte) ([]byte, error) {
 // Put associates a value with key.
 func (t *Table) Put(key, value []byte) error {
 	// Ignore if value is the same.
-	if v, err := t.Get(key); err != nil && err != ErrKeyNotFound {
+	if v, err := t.Get(key); err != nil && err != common.ErrNotFound {
 		return err
 	} else if bytes.Equal(v, value) {
 		return nil
@@ -391,7 +391,7 @@ type tableBatch struct {
 
 func (b *tableBatch) Put(key, value []byte) error {
 	// Ignore if value is the same.
-	if v, err := b.table.Get(key); err != nil && err != ErrKeyNotFound {
+	if v, err := b.table.Get(key); err != nil && err != common.ErrNotFound {
 		return err
 	} else if bytes.Equal(v, value) {
 		return nil
@@ -418,7 +418,7 @@ func (b *tableBatch) Put(key, value []byte) error {
 
 func (b *tableBatch) Delete(key []byte) error {
 	// Ignore if value doesn't exist.
-	if _, err := b.table.Get(key); err == ErrKeyNotFound {
+	if _, err := b.table.Get(key); err == common.ErrNotFound {
 		return nil
 	} else if err != nil {
 		return err

--- a/ethdb/table_test.go
+++ b/ethdb/table_test.go
@@ -64,7 +64,7 @@ func TestTable_Delete(t *testing.T) {
 		t.Fatal("expected value to not exist")
 	}
 
-	if _, err := tbl.Get(numHashKey('b', 1000, common.Hash{})); err != ethdb.ErrKeyNotFound {
+	if _, err := tbl.Get(numHashKey('b', 1000, common.Hash{})); err != common.ErrNotFound {
 		t.Fatal(err)
 	}
 }

--- a/les/odr_test.go
+++ b/les/odr_test.go
@@ -72,7 +72,7 @@ func odrGetReceipts(ctx context.Context, db common.Database, config *params.Chai
 			receipts, _ = light.GetBlockReceipts(ctx, lc.Odr(), bhash, *number)
 		}
 	}
-	if receipts == nil {
+	if len(receipts) == 0 {
 		return nil
 	}
 	rlp, _ := rlp.EncodeToBytes(receipts)
@@ -194,7 +194,7 @@ func testOdr(t *testing.T, protocol int, expFail uint64, fn odrTestFn) {
 			eq := bytes.Equal(b1, b2)
 			exp := i < expFail
 			if exp && !eq {
-				t.Errorf("odr mismatch")
+				t.Errorf("odr mismatch:\n\twant: %X\n\thave: %X", b1, b2)
 			}
 			if !exp && eq {
 				t.Errorf("unexpected odr match")

--- a/light/nodeset.go
+++ b/light/nodeset.go
@@ -17,7 +17,6 @@
 package light
 
 import (
-	"errors"
 	"sync"
 
 	"github.com/gochain-io/gochain/common"
@@ -68,7 +67,7 @@ func (db *NodeSet) Get(key []byte) ([]byte, error) {
 	if entry, ok := db.nodes[string(key)]; ok {
 		return entry, nil
 	}
-	return nil, errors.New("not found")
+	return nil, common.ErrNotFound
 }
 
 // Has returns true if the node set contains the given key

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -206,7 +206,7 @@ func (pool *TxPool) rollbackTxs(hash common.Hash, txc txStateChanges) {
 		}
 		delete(pool.mined, hash)
 	}
-	gbatch.Write()
+	rawdb.Must("batch delete tx lookup entries", gbatch.Write)
 }
 
 // reorgOnNewHead sets a new head header, processing (and rolling back if necessary)
@@ -506,10 +506,12 @@ func (self *TxPool) RemoveTransactions(txs types.Transactions) {
 		//self.RemoveTx(tx.Hash())
 		hash := tx.Hash()
 		delete(self.pending, hash)
-		batch.Delete(hash[:])
+		rawdb.Must("add tx delete to batch", func() error {
+			return batch.Delete(hash[:])
+		})
 		hashes = append(hashes, hash)
 	}
-	batch.Write()
+	rawdb.Must("batch delete txs", batch.Write)
 	self.relay.Discard(hashes)
 }
 


### PR DESCRIPTION
This PR adds a `rawdb.Must` function for retrying various db operations when appropriate (e.g. s3 timeouts), rather than shutting down suddenly with a `log.Crit` call.