### PR TITLE
eth: break 'bestPeer' total difficulty ties with head hash

### DIFF
--- a/eth/sync.go
+++ b/eth/sync.go
@@ -228,10 +228,13 @@ func (pm *ProtocolManager) synchronise(ctx context.Context, peer *peer) {
 	}
 	// Make sure the peer's TD is higher than our own
 	currentBlock := pm.blockchain.CurrentBlock()
-	td := pm.blockchain.GetTd(currentBlock.Hash(), currentBlock.NumberU64())
+	hash := currentBlock.Hash()
+	td := pm.blockchain.GetTd(hash, currentBlock.NumberU64())
 
 	pHead, pTd := peer.Head()
-	if pTd.Cmp(td) <= 0 {
+	if cmp := pTd.Cmp(td); cmp < 0 {
+		return
+	} else if cmp == 0 && pHead.Big().Cmp(hash.Big()) <= 0 {
 		return
 	}
 	// Otherwise try to sync with the downloader


### PR DESCRIPTION
This PR makes `peerSet.BestPeer` deterministic to prevent deadlock. Previously, multiple competing heads could have the same total difficulty, causing the 'best' peer to be somewhat arbitrary. Additionally, a node would discard a sync with a peer of equal total difficulty. During normal propagation, we have tie breakers based on block number and gas used - but this information is not available for peers - they only share their head hash and total difficulty during a handshake. This change uses the head hash to make deterministic tie-break decisions between peers with equal total difficulties, and also enables syncing with a peer with the same TD depending on the same hash tie-breaker.

This change was deployed on the testnet and resolved a real deadlock (3 competing heads, two different block numbers) which was hung for ~2 hours.