### PR TITLE
Add 'gochain-ethdb keys' command.

### DIFF
--- a/cmd/gochain-ethdb/keys.go
+++ b/cmd/gochain-ethdb/keys.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/gochain-io/gochain/ethdb"
+)
+
+type KeysCommand struct{}
+
+func NewKeysCommand() *KeysCommand {
+	return &KeysCommand{}
+}
+
+func (cmd *KeysCommand) Run(args []string) error {
+	fs := flag.NewFlagSet("gochain-ethdb-keys", flag.ContinueOnError)
+	tableName := fs.String("table", "", "table name")
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if fs.NArg() == 0 {
+		return errors.New("path required")
+	} else if *tableName == "" {
+		return errors.New("table name required")
+	}
+
+	// Open db.
+	db := ethdb.NewDB(fs.Arg(0))
+	db.MinCompactionAge = 0
+	if err := db.Open(); err != nil {
+		return err
+	}
+	defer db.Close()
+
+	// Open table.
+	tbl := db.Table(*tableName)
+	if tbl == nil {
+		return fmt.Errorf("unknown table name: %q", *tableName)
+	}
+
+	// Iterate over all segments
+	segments := tbl.SegmentSlice()
+	for _, segment := range segments {
+		itr := segment.Iterator()
+		for itr.Next() {
+			fmt.Printf("%x\t%d\n", itr.Key(), len(itr.Value()))
+		}
+		itr.Close()
+	}
+
+	return nil
+}

--- a/cmd/gochain-ethdb/main.go
+++ b/cmd/gochain-ethdb/main.go
@@ -27,6 +27,8 @@ func run(args []string) error {
 		return nil
 	case "check":
 		return NewCheckCommand().Run(args)
+	case "keys":
+		return NewKeysCommand().Run(args)
 	default:
 		return fmt.Errorf("unknown command: %q", cmd)
 	}
@@ -44,5 +46,6 @@ The commands are:
 
 	check       verify integrity of a segment
 	help        print this screen
+	keys        dump all keys for a table
 `[1:])
 }

--- a/ethdb/db.go
+++ b/ethdb/db.go
@@ -148,6 +148,22 @@ func (db *DB) Tables() []*Table {
 	return []*Table{db.global, db.body, db.header, db.receipt}
 }
 
+// Table returns a table by name.
+func (db *DB) Table(name string) *Table {
+	switch name {
+	case "global":
+		return db.global
+	case "body":
+		return db.body
+	case "header":
+		return db.header
+	case "receipt":
+		return db.receipt
+	default:
+		return nil
+	}
+}
+
 // migrate converts a source LevelDB database to the new ethdb formatted database.
 func (db *DB) migrate() error {
 	const suffix = ".migrating"


### PR DESCRIPTION
Prints all keys (hex-encoded) and their value sizes in a tab-delimited format.

## Usage

```sh
$ gochain-ethdb keys -table global /path/to/chaindata
```