### PR TITLE
core/rawdb: retry ReadBloomBits and ignore ErrNotFound

### DIFF
--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -105,13 +105,21 @@ func ReadReceipt(db common.Database, hash common.Hash) (*types.Receipt, common.H
 
 // ReadBloomBits retrieves the compressed bloom bit vector belonging to the given
 // section and bit index from the.
-func ReadBloomBits(db DatabaseReader, bit uint, section uint64, head common.Hash) ([]byte, error) {
+func ReadBloomBits(db DatabaseReader, bit uint, section uint64, head common.Hash) []byte {
 	var key [43]byte
 	key[0] = bloomBitsPrefix
 	binary.BigEndian.PutUint16(key[1:], uint16(bit))
 	binary.BigEndian.PutUint64(key[3:], section)
 	copy(key[11:], head[:])
-	return db.Get(key[:])
+	var data []byte
+	Must("get bloom bits", func() (err error) {
+		data, err = db.Get(key[:])
+		if err == common.ErrNotFound {
+			err = nil
+		}
+		return
+	})
+	return data
 }
 
 // WriteBloomBits stores the compressed bloom bits vector belonging to the given

--- a/eth/bloombits.go
+++ b/eth/bloombits.go
@@ -62,12 +62,9 @@ func (gc *GoChain) startBloomHandlers() {
 					task.Bitsets = make([][]byte, len(task.Sections))
 					for i, section := range task.Sections {
 						head := rawdb.ReadCanonicalHash(gc.chainDb, (section+1)*params.BloomBitsBlocks-1)
-						if compVector, err := rawdb.ReadBloomBits(gc.chainDb.GlobalTable(), task.Bit, section, head); err == nil {
-							if blob, err := bitutil.DecompressBytes(compVector, int(params.BloomBitsBlocks)/8); err == nil {
-								task.Bitsets[i] = blob
-							} else {
-								task.Error = err
-							}
+						compVector := rawdb.ReadBloomBits(gc.chainDb.GlobalTable(), task.Bit, section, head)
+						if blob, err := bitutil.DecompressBytes(compVector, int(params.BloomBitsBlocks)/8); err == nil {
+							task.Bitsets[i] = blob
 						} else {
 							task.Error = err
 						}

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -156,7 +156,7 @@ func (b *testBackend) ServiceFilter(ctx context.Context, session *bloombits.Matc
 				for i, section := range task.Sections {
 					if rand.Int()%4 != 0 { // Handle occasional missing deliveries
 						head := rawdb.ReadCanonicalHash(b.db, (section+1)*params.BloomBitsBlocks-1)
-						task.Bitsets[i], _ = rawdb.ReadBloomBits(b.db.GlobalTable(), task.Bit, section, head)
+						task.Bitsets[i] = rawdb.ReadBloomBits(b.db.GlobalTable(), task.Bit, section, head)
 					}
 				}
 				request <- task

--- a/light/odr_util.go
+++ b/light/odr_util.go
@@ -205,16 +205,8 @@ func GetBloomBits(ctx context.Context, odr OdrBackend, bitIdx uint, sectionIdxLi
 		// if we don't have the canonical hash stored for this section head number, we'll still look for
 		// an entry with a zero sectionHead (we store it with zero section head too if we don't know it
 		// at the time of the retrieval)
-		bloomBits, err := rawdb.ReadBloomBits(db.GlobalTable(), bitIdx, sectionIdx, sectionHead)
-		if err == nil {
-			result[i] = bloomBits
-		} else {
-			if sectionIdx >= bloomTrieCount {
-				return nil, ErrNoTrustedBloomTrie
-			}
-			reqList = append(reqList, sectionIdx)
-			reqIdx = append(reqIdx, i)
-		}
+		result[i] = rawdb.ReadBloomBits(db.GlobalTable(), bitIdx, sectionIdx, sectionHead)
+
 	}
 	if reqList == nil {
 		return result, nil

--- a/light/postprocess.go
+++ b/light/postprocess.go
@@ -278,10 +278,7 @@ func (b *BloomTrieIndexerBackend) Commit() error {
 		binary.BigEndian.PutUint64(encKey[2:10], b.section)
 		var decomp []byte
 		for j := uint64(0); j < b.bloomTrieRatio; j++ {
-			data, err := rawdb.ReadBloomBits(b.diskdb.GlobalTable(), i, b.section*b.bloomTrieRatio+j, b.sectionHeads[j])
-			if err != nil {
-				return err
-			}
+			data := rawdb.ReadBloomBits(b.diskdb.GlobalTable(), i, b.section*b.bloomTrieRatio+j, b.sectionHeads[j])
 			decompData, err2 := bitutil.DecompressBytes(data, int(b.parentSectionSize/8))
 			if err2 != nil {
 				return err2


### PR DESCRIPTION
This PR aligns `rawdb.ReadBloomBits` with the other read methods by using the retry logic and returning empty data instead of an error when a value is 'not found'.