### PR TITLE
miner: stabilize worker commit start delay

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -795,10 +795,11 @@ func (w *worker) commitNewWork(ctx context.Context, interrupt *int32, noempty bo
 	tstart := time.Now()
 	parent := w.chain.CurrentBlock()
 
-	if parent.Time().Cmp(new(big.Int).SetInt64(timestamp)) >= 0 {
-		timestamp = parent.Time().Int64() + 1
+	// Don't start sooner than 1s after the parent.
+	if earliest := parent.Time().Int64() + 1; earliest > timestamp {
+		timestamp = earliest
 	}
-	// this will ensure we're not going off too far in the future
+	// Wait to ensure we're not going off too far in the future.
 	if wait := time.Until(time.Unix(timestamp, 0)); wait > 0 {
 		log.Info("Mining too far in the future", "wait", common.PrettyDuration(wait))
 		time.Sleep(wait)


### PR DESCRIPTION
This PR adjusts the worker commit start delay to make it more stable.
Previously, if `timestamp` was earlier than the `parent`'s, then it was set to `parent + 1`, but if it was in first second after the `parent`, then it went through undelayed. This means that a later arrival could actually go through sooner. Instead, anything earlier than `parent + 1` should be delayed until `parent + 1`, so no ordering is reversed - and the whole first second is open to receive the next canonical block before mining again. (Also, we don't waste any mining time since we are recommitting up to every second anyways)

This might help with the patterned propagation delays we've been seeing on the testnet:
![screenshot from 2018-11-16 09-11-35](https://user-images.githubusercontent.com/1194128/48636437-b3b67e00-e97f-11e8-8ef3-f7229c1d1839.png)
