### PR TITLE
WIP - miner: more tracing of miner commit methods

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1079,7 +1079,7 @@ func reorg(local, external chainHead) bool {
 //
 // After insertion is done, all accumulated events will be fired.
 func (bc *BlockChain) InsertChain(ctx context.Context, chain types.Blocks) (int, error) {
-	ctx, span := trace.StartSpan(ctx, "BlockChain.InsertChain")
+	ctx, span := trace.StartSpan(ctx, "BlockChain.InsertChain", trace.WithSampler(trace.AlwaysSample()))
 	defer span.End()
 	span.AddAttributes(trace.Int64Attribute("len", int64(len(chain))))
 


### PR DESCRIPTION
This PR enhances tracing with more named spans and by 'always sampling' some per-block spans.

![screenshot from 2018-11-19 09-13-38](https://user-images.githubusercontent.com/1194128/48723430-78b08680-ebdb-11e8-9e63-e96dc7524ce7.png)