### PR TITLE
miner: revert worker commit deadline

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -672,12 +672,7 @@ func (w *worker) commitTransactions(ctx context.Context, txs *types.Transactions
 		w.current.gasPool = new(core.GasPool).AddGas(w.current.header.GasLimit)
 	}
 
-	deadline := time.Now().Add(maxCommitTransactionsDur)
-	if w.current.header.Time != nil {
-		if alternate := time.Unix(w.current.header.Time.Int64(), 0); alternate.Before(deadline) {
-			deadline = alternate
-		}
-	}
+	start := time.Now()
 
 	tracing := log.Tracing()
 	// Create a new emv context and environment.
@@ -713,7 +708,7 @@ func (w *worker) commitTransactions(ctx context.Context, txs *types.Transactions
 			log.Info(fmt.Sprintf("Commit interrupted, %s incomplete work", action), "num", w.current.header.Number)
 			return drop
 		}
-		if time.Until(deadline) <= 0 {
+		if time.Since(start) > maxCommitTransactionsDur {
 			log.Info("Commit deadline reached", "num", w.current.header.Number)
 			break
 		}


### PR DESCRIPTION
This PR reverts #320.

This was actually working against us, because if the period deadline is hit, then less time than the limit was used and the work was not finished. Meanwhile, the previous candidates for this block had the whole time limit available and likely the same amount of work (unless the work *just arrived*), so the final deadline block usually ends up being smaller (sometimes even 0 txs) than the previous candidate from having less time, but wins by default. Instead we want to prefer blocks which had the full time limit.