### PR TITLE
cmd, core: add --local flag for persistent dev chains

### DIFF
--- a/cmd/gochain/config.go
+++ b/cmd/gochain/config.go
@@ -161,7 +161,8 @@ func makeFullNode(ctx *cli.Context) *node.Node {
 	}
 	// Whisper must be explicitly enabled by specifying at least 1 whisper flag or in dev mode
 	shhEnabled := enableWhisper(ctx)
-	shhAutoEnabled := !ctx.GlobalIsSet(utils.WhisperEnabledFlag.Name) && ctx.GlobalIsSet(utils.DeveloperFlag.Name)
+	shhAutoEnabled := !ctx.GlobalIsSet(utils.WhisperEnabledFlag.Name) &&
+		(ctx.GlobalIsSet(utils.DeveloperFlag.Name) || ctx.GlobalIsSet(utils.LocalFlag.Name))
 	if shhEnabled || shhAutoEnabled {
 		if ctx.GlobalIsSet(utils.WhisperMaxMessageSizeFlag.Name) {
 			cfg.Shh.MaxMessageSize = uint32(ctx.Int(utils.WhisperMaxMessageSizeFlag.Name))

--- a/cmd/gochain/main.go
+++ b/cmd/gochain/main.go
@@ -118,6 +118,8 @@ var (
 		utils.DeveloperFlag,
 		utils.DeveloperPeriodFlag,
 		utils.TestnetFlag,
+		utils.LocalFlag,
+		utils.LocalFundFlag,
 		utils.VMEnableDebugFlag,
 		utils.NetworkIdFlag,
 		utils.RPCCORSDomainFlag,
@@ -310,7 +312,7 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 		}
 	}()
 	// Start auxiliary services if enabled
-	if ctx.GlobalBool(utils.MiningEnabledFlag.Name) || ctx.GlobalBool(utils.DeveloperFlag.Name) {
+	if ctx.GlobalBool(utils.MiningEnabledFlag.Name) || ctx.GlobalBool(utils.DeveloperFlag.Name) || ctx.GlobalBool(utils.LocalFlag.Name) {
 		// Mining only makes sense if a full GoChain node is running
 		if ctx.GlobalBool(utils.LightModeFlag.Name) || ctx.GlobalString(utils.SyncModeFlag.Name) == "light" {
 			utils.Fatalf("Light clients do not support mining")

--- a/cmd/gochain/usage.go
+++ b/cmd/gochain/usage.go
@@ -88,6 +88,12 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.DeveloperPeriodFlag,
 		},
 	},
+	{Name: "LOCAL CHAIN",
+		Flags: []cli.Flag{
+			utils.LocalFlag,
+			utils.LocalFundFlag,
+		},
+	},
 	{
 		Name: "ETHDB",
 		Flags: []cli.Flag{


### PR DESCRIPTION
This PR adds a `--local` flag to run a local chain for development. This is similar to `--dev`, but the data persists (defaults to `.local`). By default, 10 accounts are created and their address/key pairs are logged during configuration. An optional `--local.fund` flag can be used to pass a comma separated list of addresses to fund instead.

Example usage via docker:
```sh
> docker run --name local_node -p 8545:8545 gochain/gochain:local gochain --local
INFO [02-04|20:51:46] Maximum peer count                       ETH=25 LES=0 total=25
INFO [02-04|20:51:47] Signing with account                     address=0xAB6667F7C4F1d5C82cA20170DbD9FB603441471e
INFO [02-04|20:52:13] Pre-funded accounts:

		Address						Key
	0x5725A325836eb783f993a1007141599109125412 0xfa242528ea8bbdab9d178fd7e485c77a6755dcfc61490d21f89384919663c539
	0x44A80d6e88B656a69D5eb540F485d6Baf135a0c8 0xcc6e805b196b84cf8db462953b05a1344026a6c65357f6a68b454f10b55ee766
	0x9eD2EF6DE60EbE281f74e9A0f7D266A88F53A73E 0xb5bd428e207974d5c8f0f2e129b1740fdc33731b61bc06a92ecf2d483e3030d6
	0x481d6f8Fe38B1c36C6A4634477ECFAc3e6e81132 0x41e8d8bf5bfab4444d6ab9b02457aa9fe7a0b7a4cad6bd00c1e67639df09a0af
	0x3882c5837a2596DA4347eC26352ded6c45f33130 0xf5ffe88085958ddf32a85f094fb71ff54597792c8df5286acc2b08011d677573
	0x6521e464493077085FbC3Bd75B6a1AE3539B6D76 0x27eecbcbfb3742ab02c38f03eaa519c60d6dc48df9adda32ade78f5952c1327b
	0xBC3700d6E74e05866Ed5178c0338bF59C678663B 0xa089533d98f6526ed09e0668b8f8a5649a1b8899fa6d7c53c3293b125eab3228
	0x6dE70aABC001DDa1177A2306A739cEd521b90689 0xb7fc2aebb55d7918a6b6757f12dca75e9296d29158ff998a4e8a6a618700eb0f
	0x135E58bB0Ea08fd388c370ed229E233Bf9Bdfe9B 0x84249a6dbffad2c57a43c57d8c01d79c8b76c91a0996a2edce58ee1f1bf1c1aa
	0x634639241b1a25F2c7eEe5222D8eB929d6D14f42 0x1187a6a8ddd7f97df7f1eebde90cea7c07c40525cfe91826630686c55ff761a6
 
INFO [02-04|20:52:13] Starting peer-to-peer node               instance=GoChain/v3.0.4/linux-amd64/go1.12beta2
...
```
Calling from `web3`:
```sh
> web3 -n localhost addr 0x634639241b1a25F2c7eEe5222D8eB929d6D14f42
Balance: 1000000000000000000000
Code: 
```

The data persists in the container, which can be started back up again later.

Fixes #347 

