### PR TITLE
core: limit random chain ID range so as not to overflow web3js

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -393,7 +393,7 @@ func DefaultTestnetGenesisBlock() *Genesis {
 func DeveloperGenesisBlock(period uint64, faucet common.Address) *Genesis {
 	// Override the default period to the user requested one
 	config := *params.AllCliqueProtocolChanges
-	config.ChainId = big.NewInt(rand.Int63())
+	config.ChainId = big.NewInt(int64(rand.Int31()) + 1000)
 	config.Clique.Period = period
 
 	alloc, ok := new(big.Int).SetString("1000000000000000000000000000", 10)
@@ -419,7 +419,7 @@ func DeveloperGenesisBlock(period uint64, faucet common.Address) *Genesis {
 func LocalGenesisBlock(period uint64, signer common.Address, seeds []common.Address) *Genesis {
 	// Override the default period to the user requested one
 	config := *params.AllCliqueProtocolChanges
-	config.ChainId = big.NewInt(rand.Int63())
+	config.ChainId = big.NewInt(int64(rand.Int31()) + 1000)
 	config.Clique.Period = period
 
 	alloc, ok := new(big.Int).SetString("1000000000000000000000", 10)


### PR DESCRIPTION
This PR changes the random net/chain ID generation from a 64 bit integer to a 32 bit integer plus 1000 (to push it above 'regular' looking IDs). This will keep the IDs well under 53 bits, which is the max web3js can handle.