### PR TITLE
core, params: set mainnet constantinople fork for block #5100000

### DIFF
--- a/core/genesis-main.json
+++ b/core/genesis-main.json
@@ -7,6 +7,7 @@
     "eip155Block": 0,
     "eip158Block": 0,
     "byzantiumBlock": 0,
+    "constantinopleBlock": 5100000,
     "clique": {
       "period": 5,
       "epoch": 3000

--- a/params/config.go
+++ b/params/config.go
@@ -43,7 +43,7 @@ var (
 		EIP155Block:         big.NewInt(0),
 		EIP158Block:         big.NewInt(0),
 		ByzantiumBlock:      big.NewInt(0),
-		ConstantinopleBlock: nil,
+		ConstantinopleBlock: big.NewInt(5100000),
 		PetersburgBlock:     nil,
 
 		Clique: DefaultCliqueConfig(),


### PR DESCRIPTION
This PR sets the mainnet Constantinople fork for block number 5,100,000 - around 5:12AM, Thursday March 7th UTC.

Closes #332