### PR TITLE
upgrade Dockerfile and CI to go1.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.0
 defaults: &defaults
   working_directory: /go/src/github.com/gochain-io/gochain
   docker:
-    - image: circleci/golang:1.12beta2
+    - image: circleci/golang:1.12
   environment: # apparently expansion doesn't work here yet: https://discuss.circleci.com/t/environment-variable-expansion-in-working-directory/11322
     - OS=linux
     - ARCH=amd64
@@ -71,7 +71,7 @@ jobs:
     environment: # apparently expansion doesn't work here yet: https://discuss.circleci.com/t/environment-variable-expansion-in-working-directory/11322
       - GOPATH=/home/circleci/go
       - GOCACHE=/tmp/go/cache
-      - GOVERSION=1.12beta2
+      - GOVERSION=1.12
       - GO111MODULE=on
       - OS=linux
       - ARCH=amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build GoChain in a stock Go builder container
-FROM golang:1.12beta2-alpine as builder
+FROM golang:1.12-alpine as builder
 
 RUN apk --no-cache add build-base git bzr mercurial gcc linux-headers
 ENV D=/gochain


### PR DESCRIPTION
Go 1.12 was released. This PR upgrades Docker and CI from go1.12beta2 to go1.12.